### PR TITLE
On workers: evict a partition if going out of memory

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -164,18 +164,24 @@ function MemoryManager() {
 	this.storageMemory = 0;
 	this.shuffleMemory = 0;
 	this.collectMemory = 0;
+	this.sizeOf = sizeOf;
+	this.memoryUsage = process.memoryUsage;
 
-	this.storageFull = function() {return (this.storageMemory > maxStorageMemory);};
-	this.shuffleFull = function() {return (this.shuffleMemory > maxShuffleMemory);};
-	this.collectFull = function() {return (this.collectMemory > maxCollectMemory);};
+	this.storageFull = function () {return (this.storageMemory > maxStorageMemory);};
+	this.shuffleFull = function () {return (this.shuffleMemory > maxShuffleMemory);};
+	this.collectFull = function () {return (this.collectMemory > maxCollectMemory);};
 
 	this.partitions = {};
-	this.register = function(partition) {
+	this.register = function (partition) {
 		var key = partition.datasetId + '.' + partition.partitionIndex;
 		if (!(key in this.partitions)) this.partitions[key] = partition;
 	};
 
-	this.isAvailable = function(partition) {
+	this.unregister = function (partition) {
+		this.partitions[partition.datasetId + '.' + partition.partitionIndex] = undefined;
+	};
+
+	this.isAvailable = function (partition) {
 		return (this.partitions[partition.datasetId + '.' + partition.partitionIndex] != undefined);
 	};
 }

--- a/examples/ml/logreg.js
+++ b/examples/ml/logreg.js
@@ -32,7 +32,7 @@ console.log('Iterations: ' + nIterations + '\n');
 console.log('Approximate dataset size: ' + Math.ceil(approx_data_size / (1024 * 1024)) + ' Mb');
 
 var sc = skale.context();
-var points = file ? sc.textFile(file).map(function (e) {
+var points = file ? sc.textFile(file, P).map(function (e) {
 	var tmp = e.split(' ').map(parseFloat);
 	return [tmp.shift(), tmp];
 }).persist() : ml.randomSVMData(sc, N, D, seed, P).persist();

--- a/lib/context.js
+++ b/lib/context.js
@@ -260,6 +260,7 @@ function Task(contextId, jobId, nodes, datasetId, pid, action) {
 			if (tmpPartAvailable || (tmpPart.parentDatasetId == undefined)) break;		// source partition found
 			pipeline.unshift(tmpDataset);												// else add current dataset transform to pipeline
 			tmpPart = this.nodes[tmpPart.parentDatasetId].partitions[tmpPart.parentPartitionIndex];
+			tmpPart.mm = this.mm;
 			tmpDataset = this.nodes[tmpPart.datasetId];
 		}
 

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -265,8 +265,33 @@ function Partition(datasetId, partitionIndex, parentDatasetId, parentPartitionIn
 	this.partitionIndex = partitionIndex;
 	this.parentDatasetId = parentDatasetId;
 	this.parentPartitionIndex = parentPartitionIndex;
+	this.count = 0;
+	this.bsize = 0;		// estimated size of memory increment per period
+	this.tsize = 0;		// estimated total partition size
+	this.skip = false;	// true when partition is evicted due to memory shortage
 
 	this.transform = function(context, data) {
+		if (this.skip) return data;	// Passthrough if partition is evicted
+
+		// Periodically check/update available memory, and evict partition
+		// if necessary. In this case it will be recomputed if required by
+		// a future action.
+		if (this.count++ == 9999) {
+			this.count = 0;
+			if (this.bsize == 0) this.bsize = this.mm.sizeOf(this.data);
+			this.tsize += this.bsize;
+			this.mm.storageMemory += this.bsize;
+			if (this.mm.storageFull()) {
+				console.log('# Out of memory, evict partition', this.partitionIndex);
+				this.skip = true;
+				this.mm.storageMemory -= this.tsize;
+				this.data = [];
+				this.mm.unregister(this);
+				return data;
+			}
+		}
+
+		// Perform persistence of partition in memory here
 		for (var i = 0; i < data.length; i++) this.data.push(data[i]);
 		return data;
 	};


### PR DESCRIPTION
When no more memory is available, automatically un-persist a
partition in memory, forcing it to be recomputed if required by
a further action.