### PR TITLE
Serverless version, direct IPCs between workers and master

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,15 @@
 
 'use strict';
 
-//var Context = require('./lib/context.js');
-var Context = require('./lib/context-local.js');
+var ContextRemote = require('./lib/context.js');
+var ContextLocal = require('./lib/context-local.js');
 var Dataset = require('./lib/dataset.js');
+
+function Context(args) {
+	args = args || {};
+	if (args.host || process.env.SKALE_HOST) return ContextRemote(args);
+	return ContextLocal(args);
+}
 
 module.exports = {
 	Context: Context,

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 'use strict';
 
-var Context = require('./lib/context.js');
+//var Context = require('./lib/context.js');
+var Context = require('./lib/context-local.js');
 var Dataset = require('./lib/dataset.js');
 
 module.exports = {

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -25,7 +25,6 @@ function Context(args) {
 		this.worker[i] = new Worker(i);
 	}
 	this.jobId = 0;
-	this.grid = {};	// Legacy compatibility. To be removed.
 
 	this.basedir = tmp + '/skale/' + this.contextId + '/';
 	mkdirp.sync(this.basedir + 'tmp');
@@ -259,13 +258,7 @@ function Task(basedir, jobId, nodes, datasetId, pid, action) {
 
 	this.getReadStream = function (fileObj, opt) {
 		var fs = this.lib.fs;
-		try {
-			fs.accessSync(fileObj.path);
-			return fs.createReadStream(fileObj.path, opt);
-		} catch (err) {
-			if (!fileObj.host) fileObj.host = this.grid.muuid;
-			return this.grid.createStreamFrom(fileObj.host, {cmd: 'sendFile', path: fileObj.path, opt: opt});
-		}
+		return fs.createReadStream(fileObj.path, opt);
 	};
 }
 

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -25,6 +25,7 @@ function Context(args) {
 		this.worker[i] = new Worker(i);
 	}
 	this.jobId = 0;
+	this.grid = {};	// Legacy compatibility. To be removed.
 
 	this.basedir = tmp + '/skale/' + this.contextId + '/';
 	mkdirp.sync(this.basedir + 'tmp');
@@ -150,8 +151,6 @@ function Context(args) {
 				} else cout(n, done);
 			});
 		}
-
-//		return stream;
 	};
 
 	function rpc(cmd, workerNum, args, callback) {
@@ -161,10 +160,6 @@ function Context(args) {
 }
 
 Context.prototype.log = log;
-
-Context.prototype.info = function() {
-	return this.worker;
-};
 
 Context.prototype.end = function () {
 	rimraf(this.basedir, function (err) {

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -4,6 +4,7 @@
 
 var child_process = require('child_process');
 var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
 var uuid = require('node-uuid');
 var dataset = require('./dataset.js');
 
@@ -166,6 +167,9 @@ Context.prototype.info = function() {
 };
 
 Context.prototype.end = function () {
+	rimraf(this.basedir, function (err) {
+		if (err) log('remove', err);
+	});
 	for (var i = 0; i < this.worker.length; i++) {
 		this.worker[i].child.disconnect();
 	}
@@ -181,7 +185,6 @@ function Worker(index) {
 	});
 	var self = this;
 
-	log('start worker', index);
 	this.child.on('message', function(msg) {
 		if (self.reqcb[msg.id]) {
 			self.reqcb[msg.id](msg.error, msg.result);

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -40,16 +40,12 @@ function Context(args) {
 	this.runTask = function(task, callback) {
 		function getLeastBusyWorkerId(/* preferredLocation */) {
 			var wid, ntask;
-			log('worker.length', self.worker.length);
 			for (var i = 0; i < self.worker.length; i++) {
-				log('ntask', ntask);
-				log('self.worker[i].ntask', self.worker[i].ntask);
 				if ((ntask == undefined) || (ntask > self.worker[i].ntask)) {
 					ntask = self.worker[i].ntask;
 					wid = i;
 				}
 			}
-			log('wid', wid);
 			return wid;
 		}
 

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -2,97 +2,32 @@
 
 'use strict';
 
-var fs = require('fs');
-var util = require('util');
-var uuid = require('node-uuid');
+var child_process = require('child_process');
 var mkdirp = require('mkdirp');
-
-var SkaleClient = require('./client.js');
+var uuid = require('node-uuid');
 var dataset = require('./dataset.js');
 
-module.exports = SkaleContext;
+var memory = 4096;
 
-util.inherits(SkaleContext, SkaleClient);
+module.exports = Context;
 
-function SkaleContext(arg) {
-	if (!(this instanceof SkaleContext))
-		return new SkaleContext(arg);
+function Context(args) {
+	if (!(this instanceof Context))
+		return new Context(args);
+	this.id = 1;
+	this.contextId = uuid.v4();
+	var nworker = 3;
+	var tmp = process.env.SKALE_TMP || '/tmp';
 	var self = this;
-
-	arg = arg || {};
-	arg.data = arg.data || {};
-	arg.data.type = 'master';
-	SkaleClient.call(this, arg);
-	var maxWorker = process.env.SKALE_MAX_WORKER;
-	var tmp = arg.tmp || process.env.SKALE_TMP || '/tmp';
-
-	this.started = this.ended = false;
+	this.worker = new Array(nworker);
+	for (var i = 0; i < nworker; i++) {
+		this.worker[i] = new Worker(i);
+	}
 	this.jobId = 0;
-	this.worker = [];
-	this.contextId = uuid.v4();	// context id which will be used as scratch directory name
 
 	this.basedir = tmp + '/skale/' + this.contextId + '/';
 	mkdirp.sync(this.basedir + 'tmp');
 	mkdirp.sync(this.basedir + 'stream');
-
-	this.once('connect', function(data) {
-		var i;
-		process.title = 'skale-master_' + data.devices[0].wsid + ' ' + __filename;
-		if (!maxWorker || maxWorker > data.devices.length)
-			maxWorker = data.devices.length;
-		for (i = 0; i < maxWorker; i++) {
-			self.worker.push(new Worker(data.devices[i]));
-		}
-		self.started = true;
-	});
-
-	this.on('workerError', function workerError(msg) {
-		console.error('Error from worker id %d:', msg.from);
-		console.error(msg.args);
-	});
-
-	this.on('remoteClose', function getWorkerClose() {
-		throw 'Fatal error: unexpected worker exit';
-	});
-
-	this.getWorkers = function (callback) {
-		if (self.started) return callback();
-		this.once('connect', callback);
-	};
-
-	function Worker(w) {
-		this.uuid = w.uuid;
-		this.id = w.id;
-		this.ip = w.ip;
-		this.ntask = 0;
-	}
-
-	Worker.prototype.rpc = function (cmd, args, done) {
-		self.request({uuid: this.uuid, id: this.id}, {cmd: cmd, args: args}, done);
-	};
-
-	Worker.prototype.send = function (cmd, args) {
-		self.send(this.uuid, {cmd: cmd, args: args});
-	};
-
-	this.on('request', function (msg) { // Protocol to handle stream flow control: reply when data is consumed
-		if (msg.data.cmd == 'stream') {
-			self.emit(msg.data.stream, msg.data.data, function() {
-				try {self.reply(msg);} catch(err) { console.log(err); }
-			});
-		}
-	});
-
-	this.on('sendFile', function (msg) {
-		fs.createReadStream(msg.path, msg.opt).pipe(self.createStreamTo(msg));
-	});
-
-	this.end = function () {
-		if (self.ended) return;
-		self.ended = true;
-		if (this.started) self.set({complete: 1});
-		self._end();
-	};
 
 	this.datasetIdCounter = 0;	// global dataset id counter
 
@@ -135,21 +70,21 @@ function SkaleContext(arg) {
 
 	this.runJob = function(opt, root, action, callback) {
 		var jobId = this.jobId++;
-		var stream = new this.createReadStream(jobId, opt);	// user readable stream instance
+		//var stream = new this.createReadStream(jobId, opt);	// user readable stream instance
 
-		this.getWorkers(function () {
-			findShuffleStages(function(shuffleStages) {
-				if (shuffleStages.length == 0) runResultStage();
-				else {
-					var cnt = 0;
-					runShuffleStage(shuffleStages[cnt], shuffleDone);
-				}
-				function shuffleDone() {
-					if (++cnt < shuffleStages.length) runShuffleStage(shuffleStages[cnt], shuffleDone);
-					else runResultStage();
-				}
-			});
+		//this.getWorkers(function () {
+		findShuffleStages(function(shuffleStages) {
+			if (shuffleStages.length == 0) runResultStage();
+			else {
+				var cnt = 0;
+				runShuffleStage(shuffleStages[cnt], shuffleDone);
+			}
+			function shuffleDone() {
+				if (++cnt < shuffleStages.length) runShuffleStage(shuffleStages[cnt], shuffleDone);
+				else runResultStage();
+			}
 		});
+		//});
 
 		function runShuffleStage(stage, done) {
 			findNodes(stage, function(nodes) {
@@ -178,9 +113,11 @@ function SkaleContext(arg) {
 		function runResultStage() {
 			findNodes(root, function(nodes) {
 				var tasks = [];
-				for (var i = 0; i < root.partitions.length; i++)
+				for (var i = 0; i < root.partitions.length; i++) {
 					tasks.push(new Task(self.basedir, jobId, nodes, root.id, i, action));
-				callback({id: jobId, stream: stream}, tasks);
+				}
+				//callback({id: jobId, stream: stream}, tasks);
+				callback({id: jobId}, tasks);
 			});
 		}
 
@@ -217,13 +154,54 @@ function SkaleContext(arg) {
 			});
 		}
 
-		return stream;
+//		return stream;
 	};
 
 	function rpc(cmd, workerNum, args, callback) {
-		self.request(self.worker[workerNum], {cmd: cmd, args: args, master_uuid: self.uuid, worker: self.worker}, callback);
+		//self.request(self.worker[workerNum], {cmd: cmd, args: args, master_uuid: self.uuid, worker: self.worker}, callback);
+		self.worker[workerNum].request({cmd: cmd, args: args}, callback);
 	}
 }
+
+Context.prototype.log = log;
+
+Context.prototype.info = function() {
+	return this.worker;
+};
+
+Context.prototype.end = function () {
+	for (var i = 0; i < this.worker.length; i++) {
+		this.worker[i].child.disconnect();
+	}
+};
+
+function Worker(index) {
+	this.index = index;
+	this.reqid = 1;
+	this.reqcb = {};
+	this.ntask = 0;
+	this.child = child_process.fork(__dirname + '/worker-local.js', [index, memory], {
+		execArgv: ['--max_old_space_size=' + memory]
+	});
+	var self = this;
+
+	log('start worker', index);
+	this.child.on('message', function(msg) {
+		if (self.reqcb[msg.id]) {
+			self.reqcb[msg.id](msg.error, msg.result);
+			delete self.reqcb[msg.id];
+		}
+	});
+}
+
+Worker.prototype.send = function(msg) {
+	this.child.send(msg);
+};
+
+Worker.prototype.request = function (req, done) {
+	this.reqcb[this.reqid] = done;
+	this.child.send({id: this.reqid++, req: req});
+};
 
 function Task(basedir, jobId, nodes, datasetId, pid, action) {
 	this.basedir = basedir;

--- a/lib/context.js
+++ b/lib/context.js
@@ -105,16 +105,12 @@ function SkaleContext(arg) {
 	this.runTask = function(task, callback) {
 		function getLeastBusyWorkerId(/* preferredLocation */) {
 			var wid, ntask;
-			log('worker.length', self.worker.length);
 			for (var i = 0; i < self.worker.length; i++) {
-				log('ntask', ntask);
-				log('self.worker[i].ntask', self.worker[i].ntask);
 				if ((ntask == undefined) || (ntask > self.worker[i].ntask)) {
 					ntask = self.worker[i].ntask;
 					wid = i;
 				}
 			}
-			log('wid', wid);
 			return wid;
 		}
 
@@ -297,8 +293,10 @@ function Task(basedir, jobId, nodes, datasetId, pid, action) {
 	};
 }
 
+/*
 function log() {
 	var args = Array.prototype.slice.call(arguments);
 	args.unshift('[master]');
 	console.log.apply(null, args);
 }
+*/

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -643,7 +643,8 @@ function AggregateByKey(sc, dependencies, reducer, combiner, init, args) {
 					str += JSON.stringify(data) + '\n';
 				}
 				task.lib.fs.appendFileSync(path, str);
-				task.files[i] = {host: task.grid.host.uuid, path: path};
+				//task.files[i] = {host: task.grid.host.uuid, path: path};
+				task.files[i] = {path: path};
 			}
 		} else {															// AGGREGATE BY KEY
 			for (i = 0; i < this.partitions.length; i++) {
@@ -654,7 +655,8 @@ function AggregateByKey(sc, dependencies, reducer, combiner, init, args) {
 					str += JSON.stringify(data) + '\n';
 				}
 				task.lib.fs.appendFileSync(path, str);
-				task.files[i] = {host: task.grid.host.uuid, path: path};
+				//task.files[i] = {host: task.grid.host.uuid, path: path};
+				task.files[i] = {path: path};
 			}
 		}
 		done();
@@ -721,7 +723,8 @@ function Cartesian(sc, dependencies) {
 		for (var i = 0; i < this.buffer.length; i++)
 			str += JSON.stringify(this.buffer[i]) + '\n';
 		task.lib.fs.appendFileSync(path, str);
-		task.files = {host: task.grid.host.uuid, path: path};
+		//task.files = {host: task.grid.host.uuid, path: path};
+		task.files = {path: path};
 		done();
 	};
 
@@ -792,7 +795,8 @@ function SortBy(sc, dependencies, keyFunc, ascending, numPartitions) {
 				for (var j = 0; j < this.buffer[i].length; j++)
 					str += JSON.stringify(this.buffer[i][j]) + '\n';
 			task.lib.fs.appendFileSync(path, str);
-			task.files[i] = {host: task.grid.host.uuid, path: path};
+			//task.files[i] = {host: task.grid.host.uuid, path: path};
+			task.files[i] = {path: path};
 		}
 		done();
 	};
@@ -869,7 +873,8 @@ function PartitionBy(sc, dependencies, partitioner) {
 				for (var j = 0; j < this.buffer[i].length; j++)
 					str += JSON.stringify(this.buffer[i][j]) + '\n';
 			task.lib.fs.appendFileSync(path, str);
-			task.files[i] = {host: task.grid.host.uuid, path: path};
+			//task.files[i] = {host: task.grid.host.uuid, path: path};
+			task.files[i] = {path: path};
 		}
 		done();
 	};

--- a/lib/worker-local.js
+++ b/lib/worker-local.js
@@ -39,6 +39,7 @@ function runTask(msg) {
 	//task.lib = {sizeOf: sizeOf, fs: fs, readSplit: readSplit, Lines: Lines, task: task, mkdirp: mkdirp, uuid: uuid, trace: trace};
 	//task.grid = grid;
 	//task.run(function(result) {grid.reply(msg, null, result);});
+	task.grid = {};	// Legacy protocol. To be removed
 	task.mm = mm;
 	task.lib = {fs: fs, Lines: Lines, mkdirp: mkdirp, mm: mm, readSplit: readSplit,uuid: uuid};
 	task.run(function (result) {

--- a/lib/worker-local.js
+++ b/lib/worker-local.js
@@ -1,0 +1,103 @@
+// Copyright 2016 Luca-SAS, licensed under the Apache License 2.0
+
+// worker module
+
+'use strict';
+
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var uuid = require('node-uuid');
+var sizeOf = require('./rough-sizeof.js');
+var Lines = require('./lines.js');
+var readSplit = require('./readsplit.js').readSplit;
+
+var memory = process.argv[3] || 1024;
+
+var mm = new MemoryManager(memory);
+
+process.on('message', function (msg) {
+	//log('received:', msg);
+	//if (typeof msg === 'object') {
+	//	msg.result = 'ok';
+	//}
+	//process.send(msg);
+	if (typeof msg === 'object' && msg.req) {
+		switch (msg.req.cmd) {
+		case 'runTask':
+			runTask(msg);
+			break;
+		}
+	}
+});
+
+function runTask(msg) {
+	//var task = parseTask(msg.data.args);
+	var task = parseTask(msg.req.args);
+	//contextId = task.contextId;
+	// set worker side dependencies
+	//task.mm = mm;
+	//task.lib = {sizeOf: sizeOf, fs: fs, readSplit: readSplit, Lines: Lines, task: task, mkdirp: mkdirp, uuid: uuid, trace: trace};
+	//task.grid = grid;
+	//task.run(function(result) {grid.reply(msg, null, result);});
+	task.mm = mm;
+	task.lib = {fs: fs, Lines: Lines, mkdirp: mkdirp, mm: mm, readSplit: readSplit,uuid: uuid};
+	task.run(function (result) {
+		delete msg.req.args;
+		msg.result = result;
+		process.send(msg);
+	});
+}
+
+function parseTask(str) {
+	return JSON.parse(str, function(key, value) {
+		if (typeof value == 'string') {
+			// String value can be a regular function or an ES6 arrow function
+			if (value.substring(0, 8) == 'function') {
+				var args = value.match(/\(([^)]*)/)[1];
+				var body = value.replace(/^function\s*[^)]*\)\s*{/, '').replace(/}$/, '');
+				value = new Function(args, body);
+			} else if (value.match(/^\s*\(\s*[^(][^)]*\)\s*=>/) || value.match(/^\s*\w+\s*=>/))
+				value = ('indirect', eval)(value);
+		}
+		return value;
+	});
+}
+
+function MemoryManager(memory) {
+	var Kb = 1024, Mb = 1024 * Kb;
+	var MAX_MEMORY = (memory - 100) * Mb;
+	var maxStorageMemory = MAX_MEMORY * 0.4;
+	var maxShuffleMemory = MAX_MEMORY * 0.2;
+	var maxCollectMemory = MAX_MEMORY * 0.2;
+
+	this.storageMemory = 0;
+	this.shuffleMemory = 0;
+	this.collectMemory = 0;
+	this.sizeOf = sizeOf;
+
+	this.storageFull = function () {return (this.storageMemory > maxStorageMemory);};
+	this.shuffleFull = function () {return (this.shuffleMemory > maxShuffleMemory);};
+	this.collectFull = function () {return (this.collectMemory > maxCollectMemory);};
+
+	this.partitions = {};
+	this.register = function (partition) {
+		var key = partition.datasetId + '.' + partition.partitionIndex;
+		if (!(key in this.partitions)) this.partitions[key] = partition;
+	};
+
+	this.unregister = function (partition) {
+		this.partitions[partition.datasetId + '.' + partition.partitionIndex] = undefined;
+	};
+
+	this.isAvailable = function (partition) {
+		return (this.partitions[partition.datasetId + '.' + partition.partitionIndex] != undefined);
+	};
+}
+
+/*
+function log() {
+	var args = Array.prototype.slice.call(arguments);
+	args.unshift('[worker ' + process.argv[2] + ']');
+	console.log.apply(null, args);
+}
+*/

--- a/lib/worker-local.js
+++ b/lib/worker-local.js
@@ -16,11 +16,6 @@ var memory = process.argv[3] || 1024;
 var mm = new MemoryManager(memory);
 
 process.on('message', function (msg) {
-	//log('received:', msg);
-	//if (typeof msg === 'object') {
-	//	msg.result = 'ok';
-	//}
-	//process.send(msg);
 	if (typeof msg === 'object' && msg.req) {
 		switch (msg.req.cmd) {
 		case 'runTask':
@@ -31,15 +26,7 @@ process.on('message', function (msg) {
 });
 
 function runTask(msg) {
-	//var task = parseTask(msg.data.args);
 	var task = parseTask(msg.req.args);
-	//contextId = task.contextId;
-	// set worker side dependencies
-	//task.mm = mm;
-	//task.lib = {sizeOf: sizeOf, fs: fs, readSplit: readSplit, Lines: Lines, task: task, mkdirp: mkdirp, uuid: uuid, trace: trace};
-	//task.grid = grid;
-	//task.run(function(result) {grid.reply(msg, null, result);});
-	task.grid = {};	// Legacy protocol. To be removed
 	task.mm = mm;
 	task.lib = {fs: fs, Lines: Lines, mkdirp: mkdirp, mm: mm, readSplit: readSplit,uuid: uuid};
 	task.run(function (result) {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mkdirp": "^0.5.1",
     "node-getopt": "^0.2.3",
     "node-uuid": "^1.4.7",
+    "rimraf": "^2.5.2",
     "thenify": "^3.2.0",
     "websocket-stream": "^3.0.1",
     "ws": "^1.1.0"


### PR DESCRIPTION
When running on a single node, master directly forks workers and use a simplified protocol between master and workers. Less overhead, less code, less processes, less context switches, no need to start a server process and worker controllers, and better performances.
The previous distributed mode is activated if host is set in skale.context(), or if SKALE_HOST is set.