### PR TITLE
Pass user options and worker context to reduce(), aggregate() and forEach() callbacks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ node_js:
   - "0.10"
 env:
   - SKALE_WORKER_PER_HOST=2
+  - SKALE_WORKERS=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ node_js:
   - "0.12"
   - "0.10"
 env:
-  - SKALE_WORKER_PER_HOST=2
   - SKALE_WORKERS=2

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -133,6 +133,7 @@ function runWorker(host, port) {
 			var task = parseTask(msg.data.args);
 			contextId = task.contextId;
 			// set worker side dependencies
+			task.workerId = grid.host.uuid;
 			task.mm = mm;
 			task.lib = {sizeOf: sizeOf, fs: fs, readSplit: readSplit, Lines: Lines, task: task, mkdirp: mkdirp, uuid: uuid, trace: trace};
 			task.grid = grid;

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var child_process = require('child_process');
+var os = require('os');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var uuid = require('node-uuid');
@@ -15,9 +16,8 @@ module.exports = Context;
 function Context(args) {
 	if (!(this instanceof Context))
 		return new Context(args);
-	this.id = 1;
 	this.contextId = uuid.v4();
-	var nworker = 3;
+	var nworker = process.env.SKALE_WORKERS || (os.cpus().length - 1) || 1;
 	var tmp = process.env.SKALE_TMP || '/tmp';
 	var self = this;
 	this.worker = new Array(nworker);
@@ -219,12 +219,12 @@ function Task(basedir, jobId, nodes, datasetId, pid, action) {
 		if (action) {
 			if (action.foreach) {
 				pipeline.push({transform: function foreach(context, data) {
-					for (var i = 0; i < data.length; i++) action.src(data[i]);
+					for (var i = 0; i < data.length; i++) action.src(data[i], action.opt, self);
 				}});
 			} else {
 				pipeline.push({transform: function aggregate(context, data) {
 					for (var i = 0; i < data.length; i++)
-						action.init = action.src(action.init, data[i]);
+						action.init = action.src(action.init, data[i], action.opt, self);
 				}});
 			}
 		}

--- a/lib/context.js
+++ b/lib/context.js
@@ -244,12 +244,12 @@ function Task(basedir, jobId, nodes, datasetId, pid, action) {
 		if (action) {
 			if (action.foreach) {
 				pipeline.push({transform: function foreach(context, data) {
-					for (var i = 0; i < data.length; i++) action.src(data[i]);
+					for (var i = 0; i < data.length; i++) action.src(data[i], action.opt, self);
 				}});
 			} else {
 				pipeline.push({transform: function aggregate(context, data) {
 					for (var i = 0; i < data.length; i++)
-						action.init = action.src(action.init, data[i]);
+						action.init = action.src(action.init, data[i], action.opt, self);
 				}});
 			}
 		}

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -222,7 +222,7 @@ Dataset.prototype.top = thenify(function (N, done) {
 
 Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, done) {
 	opt = opt || {};
-	var action = {args: [], src: reducer, init: init, foreach: opt.foreach}, self = this;
+	var action = {args: [], src: reducer, init: init, foreach: opt.foreach, opt: opt.foreach ? opt.opt : opt}, self = this;
 
 	if (arguments.length < 5) done = opt;
 
@@ -231,7 +231,7 @@ Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, do
 
 		for (var i = 0; i < tasks.length; i++) {
 			self.sc.runTask(tasks[i], function (err, res) {
-				result = combiner(result, res.data);
+				result = combiner(result, res.data, opt);
 				if (++cnt < tasks.length) return;
 				done(err, result);
 			});
@@ -250,10 +250,9 @@ Dataset.prototype.count = thenify(function (done) {
 });
 
 Dataset.prototype.forEach = thenify(function (eacher, opt, done) {
-	opt = opt || {};
-	opt.foreach = true;
+	var arg = {opt: opt, foreach: true};
 	if (arguments.length < 3) done = opt;
-	return this.aggregate(eacher, function () {return null;}, null, opt, done);
+	return this.aggregate(eacher, function () {return null;}, null, arg, done);
 });
 
 Dataset.prototype.getPartitions = function(done) {
@@ -643,8 +642,7 @@ function AggregateByKey(sc, dependencies, reducer, combiner, init, args) {
 					str += JSON.stringify(data) + '\n';
 				}
 				task.lib.fs.appendFileSync(path, str);
-				//task.files[i] = {host: task.grid.host.uuid, path: path};
-				task.files[i] = {path: path};
+				task.files[i] = {host: task.grid.host.uuid, path: path};
 			}
 		} else {															// AGGREGATE BY KEY
 			for (i = 0; i < this.partitions.length; i++) {
@@ -655,8 +653,7 @@ function AggregateByKey(sc, dependencies, reducer, combiner, init, args) {
 					str += JSON.stringify(data) + '\n';
 				}
 				task.lib.fs.appendFileSync(path, str);
-				//task.files[i] = {host: task.grid.host.uuid, path: path};
-				task.files[i] = {path: path};
+				task.files[i] = {host: task.grid.host.uuid, path: path};
 			}
 		}
 		done();
@@ -723,8 +720,7 @@ function Cartesian(sc, dependencies) {
 		for (var i = 0; i < this.buffer.length; i++)
 			str += JSON.stringify(this.buffer[i]) + '\n';
 		task.lib.fs.appendFileSync(path, str);
-		//task.files = {host: task.grid.host.uuid, path: path};
-		task.files = {path: path};
+		task.files = {host: task.grid.host.uuid, path: path};
 		done();
 	};
 
@@ -795,8 +791,7 @@ function SortBy(sc, dependencies, keyFunc, ascending, numPartitions) {
 				for (var j = 0; j < this.buffer[i].length; j++)
 					str += JSON.stringify(this.buffer[i][j]) + '\n';
 			task.lib.fs.appendFileSync(path, str);
-			//task.files[i] = {host: task.grid.host.uuid, path: path};
-			task.files[i] = {path: path};
+			task.files[i] = {host: task.grid.host.uuid, path: path};
 		}
 		done();
 	};
@@ -873,8 +868,7 @@ function PartitionBy(sc, dependencies, partitioner) {
 				for (var j = 0; j < this.buffer[i].length; j++)
 					str += JSON.stringify(this.buffer[i][j]) + '\n';
 			task.lib.fs.appendFileSync(path, str);
-			//task.files[i] = {host: task.grid.host.uuid, path: path};
-			task.files[i] = {path: path};
+			task.files[i] = {host: task.grid.host.uuid, path: path};
 		}
 		done();
 	};

--- a/lib/worker-local.js
+++ b/lib/worker-local.js
@@ -11,6 +11,7 @@ var sizeOf = require('./rough-sizeof.js');
 var Lines = require('./lines.js');
 var readSplit = require('./readsplit.js').readSplit;
 
+var workerId = process.argv[2];
 var memory = process.argv[3] || 1024;
 
 var mm = new MemoryManager(memory);
@@ -27,6 +28,8 @@ process.on('message', function (msg) {
 
 function runTask(msg) {
 	var task = parseTask(msg.req.args);
+	task.workerId = workerId;
+	task.grid = {host: {}};
 	task.mm = mm;
 	task.lib = {fs: fs, Lines: Lines, mkdirp: mkdirp, mm: mm, readSplit: readSplit,uuid: uuid};
 	task.run(function (result) {


### PR DESCRIPTION
Despite being documented in the API reference, optional user defined argument and worker
context were not passed to reducer and combiner callbacks. This is now fixed.
The number of workers in local mode is no longer hard-coded, and can be set by SKALE_WORKERS
env variable, or the number of CPUs - 1 (if more than 2 CPUs).