### PR TITLE
If 0 workers are requested on the command line don't start any

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -271,7 +271,7 @@ if (wsport) {
 }
 
 // Start local workers if required
-if (opt.options.local) startWorker();
+if (opt.options.local && opt.options.local !== '0') startWorker();
 
 function startWorker() {
   var worker =  child_process.spawn(


### PR DESCRIPTION
It seems that there's no way to tell the server not to start any local workers.  Using --local=0 was what I expected would turn off any local workers, but that didn't seem to work.  Maybe I misunderstood how the command should be used, but if not this will fix that.