### PR TITLE
Add new stream action, which allows to stream out a dataset

### DIFF
--- a/doc/skale-API.md
+++ b/doc/skale-API.md
@@ -49,6 +49,7 @@
     - [ds.save(url[, options][, done])](#dssaveurl-options-done)
     - [ds.sortBy(keyfunc[, ascending])](#dssortbykeyfunc-ascending)
     - [ds.sortByKey(ascending)](#dssortbykeyascending)
+	- [ds.stream([opt])](#dsstream-opt)
     - [ds.subtract(other)](#dssubtractother)
     - [ds.take(num[, done])](#dstakenum-done)
     - [ds.top(num[, done])](#dstopnum-done)
@@ -176,9 +177,10 @@ alternatively through a returned [ES6 promise].
 |[forEach(func)](#dsforeachcallback-obj-done)| Apply the provided function to each element of the dataset | empty |
 |[lookup(k)](#dslookupk-done)          | Return the list of values `v` for key `k` in a `[k,v]` dataset | array of v|
 |[reduce(func, init)](#dsreducereducer-init-obj-done)| Aggregates dataset elements using a function into one value | value|
+|[save(url)](#dssaveurl-options-done)       | Save the content of a dataset to an url | empty |
+|[stream()](#dsstream-opt)            | Stream out a dataset | stream |
 |[take(num)](#dstakenum-done)         | Return the first `num` elements of dataset | array of value|
 |[top(num)](#dstopnum-done)           | Return the top `num` elements of dataset | array of value|
-|[save(url)](#dssaveurl-options-done)       | Save the content of a dataset to an url | empty |
 
 ## Skale module
 
@@ -966,6 +968,25 @@ sc.parallelize([['world', 2], ['cedric', 3], ['hello', 1]])
   .sortByKey()
   .collect().then(console.log)
 // [['cedric', 3], ['hello', 1], ['world', 2]]
+```
+
+#### ds.stream([opt])
+
+This [action] returns a [readable stream] of dataset content. The order
+of data and partitions is maintained.
+
+- *opt*: an object with the following fields:
+  - *gzip*: *Boolean*, when true, enable gzip compression. Default value: false.
+
+Example:
+
+```javascript
+var s = sc.range(4).stream();
+s.pipe(process.stdout);
+// 0
+// 1
+// 2
+// 3
 ```
 
 #### ds.subtract(other)

--- a/examples/stream.js
+++ b/examples/stream.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+var sc = require('skale-engine').context();
+// var s = sc.range(20).stream({gzip: true});
+var s = sc.range(20).stream();
+s.pipe(process.stdout);
+s.on('end', sc.end);

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -39,11 +39,28 @@ function Context(args) {
 
   this.datasetIdCounter = 0;  // global dataset id counter
 
-  this.parallelize = function (localArray, nPartitions) { return dataset.parallelize(this, localArray, nPartitions);};
-  this.range = function (start, end, step, nPartitions) { return dataset.range(this, start, end, step, nPartitions);};
+  this.parallelize = function (localArray, nPartitions) {return dataset.parallelize(this, localArray, nPartitions);};
+  this.range = function (start, end, step, nPartitions) {return dataset.range(this, start, end, step, nPartitions);};
   this.lineStream = function (stream, config) {return new dataset.Stream(this, stream, 'line', config);};
   this.objectStream = function (stream, config) {return new dataset.Stream(this, stream, 'object', config);};
   this.log = log;
+
+  this.end = function () {
+    rimraf(self.basedir, function (err) {
+      if (err) log('remove', err);
+    });
+    for (var i = 0; i < self.worker.length; i++) {
+      try {
+        self.worker[i].child.disconnect();
+      } catch(err) {
+        console.log(err);
+      }
+    }
+  };
+
+  this.getReadStream = function (fileObj, opt) {
+    return fs.createReadStream(fileObj.path, opt);
+  };
 
   this.textFile = function (file, nPartitions) {
     var u = url.parse(file);
@@ -54,7 +71,7 @@ function Context(args) {
     return new dataset.TextFile(this, file, nPartitions);
   };
 
-  this.runTask = function(task, callback) {
+  this.runTask = function (task, callback) {
     function getLeastBusyWorkerId(/* preferredLocation */) {
       var wid, ntask;
       for (var i = 0; i < self.worker.length; i++) {
@@ -101,7 +118,7 @@ function Context(args) {
     }
   };
 
-  this.runJob = function(opt, root, action, callback) {
+  this.runJob = function (opt, root, action, callback) {
     var jobId = this.jobId++;
     //var stream = new this.createReadStream(jobId, opt); // user readable stream instance
 
@@ -208,21 +225,6 @@ function Context(args) {
     self.worker[workerNum].request({cmd: cmd, args: args}, callback);
   }
 }
-
-Context.prototype.log = log;
-
-Context.prototype.end = function () {
-  rimraf(this.basedir, function (err) {
-    if (err) log('remove', err);
-  });
-  for (var i = 0; i < this.worker.length; i++) {
-    try {
-      this.worker[i].child.disconnect();
-    } catch(err) {
-      console.log(err);
-    }
-  }
-};
 
 function Worker(index) {
   this.index = index;

--- a/lib/context.js
+++ b/lib/context.js
@@ -108,6 +108,14 @@ function SkaleContext(arg) {
   this.lineStream = function (stream, config) {return new dataset.Stream(this, stream, 'line', config);};
   this.objectStream = function (stream, config) {return new dataset.Stream(this, stream, 'object', config);};
 
+  this.getReadStream = function (fileObj, opt) {
+    try {
+      return fs.createReadStream(fileObj.path, opt);
+    } catch (err) {
+      return this.createStreamFrom(fileObj.host, {cmd: 'sendFile', path: fileObj.path, opt: opt});
+    }
+  };
+
   this.runTask = function(task, callback) {
     function getLeastBusyWorkerId(/* preferredLocation */) {
       var wid, ntask;

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -12,6 +12,7 @@ var uuid = require('node-uuid');
 var splitLocalFile = require('./readsplit.js').splitLocalFile;
 var splitHDFSFile = require('./readsplit.js').splitHDFSFile;
 var AWS = require('aws-sdk');
+var merge2 = require('merge2');
 
 function Dataset(sc, dependencies) {
   this.id = sc.datasetIdCounter++;
@@ -179,6 +180,66 @@ Dataset.prototype.collect = thenify(function (done) {
   });
 });
 
+// The stream action allows the master to return a dataset as a stream
+// Each worker spills its partitions to disk
+// then master pipes each remote partition into output stream
+Dataset.prototype.stream = function (options) {
+  options = options || {};
+  var self = this;
+  var outStream = merge2();
+  var opt = {
+    gzip: options.gzip,
+    _preIterate: function (opt, wc, p) {
+      var suffix = opt.gzip ? '.gz' : '';
+      wc.exportFile = wc.basedir + 'export/' + p + suffix;
+    },
+    _postIterate: function (acc, opt, wc, p, done) {
+      var fs = wc.lib.fs;
+      var zlib = wc.lib.zlib;
+      if (opt.gzip) {
+        fs.appendFileSync(wc.exportFile, zlib.gzipSync(acc, {
+          chunckSize: 65536,
+          level: zlib.Z_BEST_SPEED
+        }));
+      } else {
+        fs.appendFileSync(wc.exportFile, acc);
+      }
+      done(wc.exportFile);
+    }
+  };
+  var pstreams = [];
+
+  function reducer(acc, val, opt, wc) {
+    acc = acc.concat(val.toString() + '\n');
+    if (acc.length >= 65536) {
+      var fs = wc.lib.fs;
+      if (opt.gzip) {
+        var zlib = wc.lib.zlib;
+        fs.appendFileSync(wc.exportFile, zlib.gzipSync(acc, {
+          chunckSize: 65536,
+          level: zlib.Z_BEST_SPEED
+        }));
+      } else {
+        fs.appendFileSync(wc.exportFile, acc);
+      }
+      acc = '';
+    }
+    return acc;
+  }
+
+  function combiner(acc1, acc2) {
+    var p = acc2.match(/.+\/([0-9]+)/)[1];
+    pstreams[p] = self.sc.getReadStream({path: acc2});
+  }
+
+  this.aggregate(reducer, combiner, '', opt, function () {
+    for (var i = 0; i < pstreams.length; i++)
+      outStream.add(pstreams[i]);
+  });
+
+  return outStream;
+};
+
 // In save action, each worker exports its dataset partitions to
 // a destination: a directory on the master, a remote S3, a database, etc.
 // The format is JSON, one per dataset entry (dataset = stream of JSON)
@@ -332,7 +393,6 @@ Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, do
     }
 
     var n = tasks.length < nworker ? tasks.length : nworker;
-    //console.log('start result stage, partitions:', tasks.length);
     runBatch(n, 0, done);
   });
 });

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -228,8 +228,8 @@ Dataset.prototype.stream = function (options) {
   }
 
   function combiner(acc1, acc2) {
-    var p = acc2.match(/.+\/([0-9]+)/)[1];
-    pstreams[p] = self.sc.getReadStream({path: acc2});
+    var p = acc2.path.match(/.+\/([0-9]+)/)[1];
+    pstreams[p] = self.sc.getReadStream(acc2);
   }
 
   this.aggregate(reducer, combiner, '', opt, function () {

--- a/lib/task.js
+++ b/lib/task.js
@@ -69,7 +69,7 @@ Task.prototype.run = function(done) {
     if (action) {
       if (action.opt._postIterate) {
         action.opt._postIterate(action.init, action.opt, self, tmpPart.partitionIndex, function () {
-          done({data: self.exportFile});
+          done({data: {host: self.grid.host.uuid, path: self.exportFile}});
         });
       } else done({data: action.init});
     } else self.nodes[self.datasetId].spillToDisk(self, function() {

--- a/lib/task.js
+++ b/lib/task.js
@@ -69,7 +69,7 @@ Task.prototype.run = function(done) {
     if (action) {
       if (action.opt._postIterate) {
         action.opt._postIterate(action.init, action.opt, self, tmpPart.partitionIndex, function () {
-          done({data: action.init});
+          done({data: self.exportFile});
         });
       } else done({data: action.init});
     } else self.nodes[self.datasetId].spillToDisk(self, function() {

--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
   "author": "Skale team",
   "dependencies": {
     "any-promise": "^1.3.0",
-    "aws-sdk": "^2.6.1",
+    "aws-sdk": "^2.6.6",
     "bluebird": "^3.4.6",
     "line-trace": "^1.0.4",
+    "merge2": "^1.0.2",
     "mkdirp": "^0.5.1",
+    "mocha": "^3.1.0",
     "node-getopt": "^0.2.3",
     "node-uuid": "^1.4.7",
     "rimraf": "^2.5.4",


### PR DESCRIPTION
Local mode only. Distributed coming next. Doc still missing.
Partition order is preserved, and flow control is implemented.
Stream can be compressed by passing {gzip: true}.
On workers, partitions are first dumped on disk (compressed or not),
in parallel, then the master reads and outputs each partition in order.