### PR TITLE
textFile: add capability to handle single AWS S3 files, gzipped or not.

### DIFF
--- a/examples/s3file.js
+++ b/examples/s3file.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+var sc = require('skale-engine').context();
+var input = sc.textFile('s3://skale-demo/datasets/restaurants-ny.json.gz');
+//var input = sc.textFile('s3://skale-demo/datasets/restaurants-ny.json');
+//var s = input.stream();
+//s.pipe(process.stdout);
+//s.on('end', sc.end);
+
+input.count(function (err, res) {
+  console.log(res);
+  sc.end();
+});

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -65,9 +65,15 @@ function Context(args) {
   this.textFile = function (file, nPartitions) {
     var u = url.parse(file);
 
-    if (u.protocol === 's3:') return new dataset.TextS3Dir(this, file.slice(5));
-    if (file.slice(-1) === '/') return new dataset.TextDir(this, file);
-    if (file.slice(-3) === '.gz') return new dataset.GzipFile(this, file);
+    if (u.protocol === 's3:') {
+      if (file.slice(-1) === '/')
+        return new dataset.TextS3Dir(this, file.slice(5).slice(2, -1));
+      return new dataset.TextS3File(this, file.slice(5));
+    }
+    if (file.slice(-1) === '/')
+      return new dataset.TextDir(this, file);
+    if (file.slice(-3) === '.gz')
+      return new dataset.GzipFile(this, file);
     return new dataset.TextFile(this, file, nPartitions);
   };
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -4,6 +4,7 @@
 
 var fs = require('fs');
 var util = require('util');
+var url = require('url');
 var zlib = require('zlib');
 var uuid = require('node-uuid');
 var mkdirp = require('mkdirp');
@@ -103,10 +104,23 @@ function SkaleContext(arg) {
 
   this.parallelize = function (localArray, nPartitions) { return dataset.parallelize(this, localArray, nPartitions);};
   this.range = function (start, end, step, nPartitions) { return dataset.range(this, start, end, step, nPartitions);};
-  this.textFile = function (file, nPartitions) {return new dataset.TextFile(this, file, nPartitions);};
-  this.gzipFile = function (file) {return new dataset.GzipFile(this, file);};
   this.lineStream = function (stream, config) {return new dataset.Stream(this, stream, 'line', config);};
   this.objectStream = function (stream, config) {return new dataset.Stream(this, stream, 'object', config);};
+
+  this.textFile = function (file, nPartitions) {
+    var u = url.parse(file);
+
+    if (u.protocol === 's3:') {
+      if (file.slice(-1) === '/')
+        return new dataset.TextS3Dir(this, file.slice(5).slice(2, -1));
+      return new dataset.TextS3File(this, file.slice(5));
+    }
+    if (file.slice(-1) === '/')
+      return new dataset.TextDir(this, file);
+    if (file.slice(-3) === '.gz')
+      return new dataset.GzipFile(this, file);
+    return new dataset.TextFile(this, file, nPartitions);
+  };
 
   this.getReadStream = function (fileObj, opt) {
     try {

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -599,6 +599,51 @@ GzipFile.prototype.iterate = function (task, p, pipeline, done) {
   });
 };
 
+function TextS3File(sc, file) {
+  Dataset.call(this, sc);
+  var _a = file.split('/');
+  this.bucket = _a[0];
+  this.path = _a.slice(1).join('/');
+  this.type = 'TextS3File';
+}
+
+util.inherits(TextS3File, Dataset);
+
+TextS3File.prototype.getPartitions = function (done) {
+  this.partitions = [new Partition(this.id, 0)];
+  done();
+};
+
+TextS3File.prototype.iterate = function (task, p, pipeline, done) {
+  var s3 = new task.lib.AWS.S3({signatureVersion: 'v4'});
+  var rs = s3.getObject({Bucket: this.bucket, Key: this.path}).createReadStream();
+  var tail = '';
+
+  if (this.path.slice(-3) === '.gz')
+    rs = rs.pipe(task.lib.zlib.createGunzip({chunkSize: 65536}));
+
+  rs.on('data', function (chunk) {
+    var str = tail + chunk;
+    var lines = str.split(/\r\n|\r|\n/);
+    var buffer;
+    tail = lines.pop();
+    for (var i = 0; i < lines.length; i++) {
+      buffer = [lines[i]];
+      for (var t = 0; t < pipeline.length; t++)
+        buffer = pipeline[t].transform(pipeline[t], buffer);
+    }
+  });
+
+  rs.on('end', function() {
+    if (tail) {
+      var buffer = [tail];
+      for (var t = 0; t < pipeline.length; t++)
+        buffer = pipeline[t].transform(pipeline[t], buffer);
+    }
+    done();
+  });
+};
+
 function TextS3Dir(sc, dir) {
   Dataset.call(this, sc);
   var _a = dir.split('/');
@@ -611,7 +656,7 @@ util.inherits(TextS3Dir, Dataset);
 
 TextS3Dir.prototype.getPartitions = function (done) {
   var self = this;
-  var s3 = new AWS.S3();
+  var s3 = new AWS.S3({signatureVersion: 'v4'});
 
   function getList(list, token, done) {
     s3.listObjectsV2({
@@ -642,7 +687,7 @@ TextS3Dir.prototype.getPartitions = function (done) {
 TextS3Dir.prototype.iterate = function (task, p, pipeline, done) {
   var path = this.partitions[p].path;
   var tail = '';
-  var s3 = new task.lib.AWS.S3();
+  var s3 = new task.lib.AWS.S3({signatureVersion: 'v4'});
   var rs = s3.getObject({Bucket: this.bucket, Key: path}).createReadStream();
   if (path.slice(-3) === '.gz') rs = rs.pipe(task.lib.zlib.createGunzip({chunkSize: 65536}));
 
@@ -1326,6 +1371,7 @@ module.exports = {
   TextFile: TextFile,
   TextDir: TextDir,
   TextS3Dir: TextS3Dir,
+  TextS3File: TextS3File,
   Source: Source,
   Stream: Stream,
   Random: Random,


### PR DESCRIPTION
Support for AWS S3 in textFile was only available for directories. This
is now fixed. Note that applying textFile on a single S3 file implies
a single partition.