### PR TITLE
Aggregate now guarantees partitions ordering. Improve traces.

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -67,7 +67,8 @@ if (process.env.SKALE_DEBUG > 1) {
 
 if (cluster.isMaster) {
   process.title = 'skale-worker-controller';
-  cluster.setupMaster({execArgv: memory ? ['--max_old_space_size=' + memory] : undefined});
+  if (memory)
+    cluster.setupMaster({execArgv: ['--max_old_space_size=' + memory]});
   cluster.on('exit', handleExit);
   cgrid = new SkaleClient({
     debug: debug,
@@ -176,7 +177,10 @@ function runWorker(host, port) {
     task.log = log;
     task.lib = {AWS: AWS, sizeOf: sizeOf, fs: fs, readSplit: readSplit, Lines: Lines, task: task, mkdirp: mkdirp, parquet: parquet, url: url, uuid: uuid, zlib: zlib};
     task.grid = grid;
-    task.run(function(result) {grid.reply(msg, null, result);});
+    task.run(function(result) {
+      result.workerId = 'g' + grid.id;
+      grid.reply(msg, null, result);
+    });
   }
 
   function runztask(msg) {

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -225,14 +225,24 @@ function Context(args) {
         }
 
         function runNext() {
+          var totalFiles = 0, totalSize = 0;
           while (busy < nworker && index < tasks.length) {
             busy++;
             self.runTask(tasks[index++], function (err, res, task) {
               stage.shufflePartitions[res.pid].files = res.files;
               busy--;
               complete++;
-              log('part ' + task.pid + ' done. Complete: ' + complete + '/' + tasks.length);
+              var n = 0, size = 0;
+              for (var f in res.files) {
+                n++;
+                size += res.files[f].size;
+              }
+              totalFiles += n;
+              totalSize += size;
+              log('part', task.pid, 'from worker-' + res.workerId,
+                '(' + complete + '/' + tasks.length + '), shuffle out:', n, 'files,', (size/(1<<20)).toFixed(3), 'MB');
               if (complete === tasks.length) {
+                log('pre-shuffle stage done, output:', totalFiles, 'files,', (totalSize / (1 << 20)).toFixed(3), 'MB');
                 stage.executed = true;
                 return done();
               }

--- a/lib/context.js
+++ b/lib/context.js
@@ -271,14 +271,23 @@ function SkaleContext(arg) {
         }
 
         function runNext() {
+          var totalFiles = 0, totalSize = 0;
           while (busy < nworker && index < tasks.length) {
             busy++;
             self.runTask(tasks[index++], function (err, res, task) {
               stage.shufflePartitions[res.pid].files = res.files;
               busy--;
               complete++;
-              log('part ' + task.pid + ' done. Complete: ' + complete + '/' + tasks.length);
+              var n = 0, size = 0;
+              for (var f in res.files) {
+                n++;
+                size += res.files[f].size;
+              }
+              totalFiles += n;
+              totalSize += size;
+              log('part', task.pid, 'from worker-' + res.workerId, '(' + complete + '/' + tasks.length + '), shuffle out:', n, 'files,', (size/(1<<20)).toFixed(3), 'MB');
               if (complete === tasks.length) {
+                log('pre-shuffle stage done, output:', totalFiles, 'files,', (totalSize / (1 << 20)).toFixed(3), 'MB');
                 stage.executed = true;
                 return done();
               }

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -165,21 +165,7 @@ Dataset.prototype.countByKey = thenify(function (done) {
 });
 
 Dataset.prototype.collect = thenify(function (done) {
-  var reducer = function (a, b) {a.push(b); return a;};
-  var combiner = function (a, b) {return a.concat(b);};
-  var init = [], action = {args: [], src: reducer, init: init, opt: {}}, self = this;
-
-  return this.sc.runJob({}, this, action, function (job, tasks) {
-    var result = JSON.parse(JSON.stringify(init)), cnt = 0;
-    function taskDone(err, res) {
-      result = combiner(result, res.data);
-      if (++cnt < tasks.length) return self.sc.runTask(tasks[cnt], taskDone);
-      self.sc.log('result stage done');
-      done(err, result);
-    }
-
-    self.sc.runTask(tasks[cnt], taskDone);
-  });
+  return this.aggregate(function (a, b) {a.push(b); return a;}, function (a, b) {return a.concat(b);}, [], done);
 });
 
 // The stream action allows the master to return a dataset as a stream
@@ -397,10 +383,11 @@ Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, do
   if (arguments.length < 5) done = opt;
 
   return this.sc.runJob(opt, this, action, function (job, tasks) {
+    var tmp = [];   // Pending tasks results waiting for combine
     var result = JSON.parse(JSON.stringify(init));
     var nworker = self.sc.worker.length;
     var index = 0;
-    var busy = 0;
+    var busy = 0;       // Number of busy tasks, use to schedule as many tasks as workers
     var complete = 0;
     var error;
 
@@ -408,12 +395,15 @@ Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, do
       while (busy < nworker && index < tasks.length) {
         busy++;
         self.sc.runTask(tasks[index++], function (err, res, task) {
-          result = combiner(result, res.data, opt);
+          tmp[task.pid] = res.data;
           complete++;
           busy--;
-          self.sc.log('part ' + task.pid + ' done. Complete: ' + complete + '/' + tasks.length);
-          if (complete === tasks.length) return done(error, result);
-          runNext();
+          self.sc.log('part', task.pid, 'from worker-' + res.workerId, '(' + complete + '/' + tasks.length + ')');
+          if (complete < tasks.length) return runNext();
+          self.sc.log('result stage done');
+          for (var i = 0; i < tmp.length; i++)
+            result = combiner(result, tmp[i], opt);
+          done(error, result);
         });
       }
     }
@@ -617,6 +607,8 @@ util.inherits(ParquetFile, Dataset);
 ParquetFile.prototype.getPartitions = function (done) {
   this.partitions = {0: new Partition(this.id, 0)};
   this.nPartitions = 1;
+  var size = fs.statSync(this.file).size;
+  this.sc.log('source: 1 partition from local parquet file, total size:', (size / (1 << 20)).toFixed(3), 'MB');
   done();
 };
 
@@ -635,6 +627,8 @@ util.inherits(GzipFile, Dataset);
 GzipFile.prototype.getPartitions = function (done) {
   this.partitions = {0: new Partition(this.id, 0)};
   this.nPartitions = 1;
+  var size = fs.statSync(this.file).size;
+  this.sc.log('source: 1 partition from local gzip file, total size:', (size / (1 << 20)).toFixed(3), 'MB');
   done();
 };
 
@@ -760,7 +754,7 @@ TextS3Dir.prototype.getPartitions = function (done) {
       self.partitions[i] = new Partition(self.id, i);
       self.partitions[i].path = res[i].Key;
     }
-    self.sc.log(self.nPartitions, 'S3 input files, total input size:', (size / (1 << 20)).toFixed(3), 'MB');
+    self.sc.log('source:', self.nPartitions, 'partitions from S3 files, total size:', (size / (1 << 20)).toFixed(3), 'MB');
     done();
   });
 };
@@ -823,16 +817,20 @@ util.inherits(TextDir, Dataset);
 TextDir.prototype.getPartitions = function (done) {
   var self = this;
   fs.readdir(this.dir, function (err, res) {
+    var stat, size = 0;
     if (err) return done(err);
     self.partitions = {};
     if (self.options.maxFiles && self.options.maxFiles < res.length)
       self.nPartitions = self.options.maxFiles;
     else
       self.nPartitions = res.length;
-    for (var i = 0; i < res.length; i++) {
+    for (var i = 0; i < self.nPartitions; i++) {
       self.partitions[i] = new Partition(self.id, i);
       self.partitions[i].path = res[i];
+      stat = fs.statSync(self.dir + '/' + res[i]);
+      size += stat.size;
     }
+    self.sc.log('source:', self.nPartitions, 'partitions from local files, total size:', (size / (1 << 20)).toFixed(3), 'MB');
     done();
   });
 };
@@ -1117,15 +1115,15 @@ AggregateByKey.prototype.transform = function (context, data) {
 };
 
 AggregateByKey.prototype.spillToDisk = function (task, done) {
-  var i, isLeft, str, hash, data, path;
+  var i, isLeft, str, key, data, path, size;
 
   if (this.dependencies.length > 1) {                 // COGROUP
     isLeft = (this.shufflePartitions[task.pid].parentDatasetId == this.dependencies[0].id);
     for (i = 0; i < this.nPartitions; i++) {
       str = '';
       path = task.basedir + 'shuffle/' + task.lib.uuid.v4();
-      for (hash in this.buffer[i]) {
-        data = isLeft ? [JSON.parse(hash), [this.buffer[i][hash], []]] : [JSON.parse(hash), [[], this.buffer[i][hash]]];
+      for (key in this.buffer[i]) {
+        data = isLeft ? [JSON.parse(key), [this.buffer[i][key], []]] : [JSON.parse(key), [[], this.buffer[i][key]]];
         str += JSON.stringify(data) + '\n';
         if (str.length >= 65536) {
           task.lib.fs.appendFileSync(path, str);
@@ -1133,14 +1131,15 @@ AggregateByKey.prototype.spillToDisk = function (task, done) {
         }
       }
       task.lib.fs.appendFileSync(path, str);
-      task.files[i] = {host: task.grid.hostname, path: path};
+      size = task.lib.fs.statSync(path).size;
+      task.files[i] = {host: task.grid.hostname, path: path, size: size};
     }
   } else {                              // AGGREGATE BY KEY
     for (i = 0; i < this.nPartitions; i++) {
       str = '';
       path = task.basedir + 'shuffle/' + task.lib.uuid.v4();
-      for (hash in this.buffer[i]) {
-        data = [JSON.parse(hash), this.buffer[i][hash]];
+      for (key in this.buffer[i]) {
+        data = [JSON.parse(key), this.buffer[i][key]];
         str += JSON.stringify(data) + '\n';
         if (str.length >= 65536) {
           task.lib.fs.appendFileSync(path, str);
@@ -1148,7 +1147,8 @@ AggregateByKey.prototype.spillToDisk = function (task, done) {
         }
       }
       task.lib.fs.appendFileSync(path, str);
-      task.files[i] = {host: task.grid.hostname, path: path};
+      size = task.lib.fs.statSync(path).size;
+      task.files[i] = {host: task.grid.hostname, path: path, size: size};
     }
   }
   done();
@@ -1170,23 +1170,24 @@ AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
     });
     lines.on('data', function (linev) {
       for (var i = 0; i < linev.length; i++) {
-        var data = JSON.parse(linev[i]), key = data[0], value = data[1], hash = JSON.stringify(key);
-        if (cbuffer[hash] != undefined) cbuffer[hash] = self.combiner(cbuffer[hash], value, self.args, self.global);
-        else cbuffer[hash] = value;
+        var data = JSON.parse(linev[i]), key = JSON.stringify(data[0]);
+        if (cbuffer[key] === undefined) cbuffer[key] = data[1];
+        else cbuffer[key] = self.combiner(cbuffer[key], data[1], self.args, self.global);
       }
     });
     lines.on('end', done);
   }
 
   function processDone() {
-    if (++cnt == files.length) {
-      for (var key in cbuffer) {
-        var buffer = [[JSON.parse(key), cbuffer[key]]];
-        for (var t = 0; t < pipeline.length; t++)
-          buffer = pipeline[t].transform(pipeline[t], buffer);
-      }
-      done();
-    } else processShuffleFile(files[cnt], processDone);
+    if (++cnt < files.length)
+      return processShuffleFile(files[cnt], processDone);
+
+    for (var key in cbuffer) {
+      var buffer = [[JSON.parse(key), cbuffer[key]]];
+      for (var t = 0; t < pipeline.length; t++)
+        buffer = pipeline[t].transform(pipeline[t], buffer);
+    }
+    done();
   }
 };
 
@@ -1218,7 +1219,7 @@ Cartesian.prototype.transform = function (context, data) {
 };
 
 Cartesian.prototype.spillToDisk = function (task, done) {
-  var str = '', path = task.basedir + 'shuffle/' + task.lib.uuid.v4();
+  var str = '', path = task.basedir + 'shuffle/' + task.lib.uuid.v4(), size;
   for (var i = 0; i < this.buffer.length; i++) {
     str += JSON.stringify(this.buffer[i]) + '\n';
     if (str.length >= 65536) {
@@ -1227,7 +1228,8 @@ Cartesian.prototype.spillToDisk = function (task, done) {
     }
   }
   task.lib.fs.appendFileSync(path, str);
-  task.files = {host: task.grid.hostname, path: path};
+  size = task.lib.fs.statSync(path).size;
+  task.files = {host: task.grid.hostname, path: path, size: size};
   task.log(task.files);
   done();
 };
@@ -1298,7 +1300,7 @@ SortBy.prototype.transform = function (context, data) {
 
 SortBy.prototype.spillToDisk = function (task, done) {
   for (var i = 0; i < this.nPartitions; i++) {
-    var str = '', path = task.basedir + 'shuffle/' + task.lib.uuid.v4();
+    var str = '', path = task.basedir + 'shuffle/' + task.lib.uuid.v4(), size;
     if (this.buffer[i] != undefined) {
       for (var j = 0; j < this.buffer[i].length; j++) {
         str += JSON.stringify(this.buffer[i][j]) + '\n';
@@ -1309,7 +1311,8 @@ SortBy.prototype.spillToDisk = function (task, done) {
       }
     }
     task.lib.fs.appendFileSync(path, str);
-    task.files[i] = {host: task.grid.hostname, path: path};
+    size = task.lib.fs.statSync(path).size;
+    task.files[i] = {host: task.grid.hostname, path: path, size: size};
   }
   done();
 };
@@ -1385,7 +1388,7 @@ PartitionBy.prototype.transform = function (context, data) {
 
 PartitionBy.prototype.spillToDisk = function (task, done) {
   for (var i = 0; i < this.nPartitions; i++) {
-    var str = '', path = task.basedir + 'shuffle/' + task.lib.uuid.v4();
+    var str = '', path = task.basedir + 'shuffle/' + task.lib.uuid.v4(), size;
     if (this.buffer[i] != undefined) {
       for (var j = 0; j < this.buffer[i].length; j++) {
         str += JSON.stringify(this.buffer[i][j]) + '\n';
@@ -1396,7 +1399,8 @@ PartitionBy.prototype.spillToDisk = function (task, done) {
       }
     }
     task.lib.fs.appendFileSync(path, str);
-    task.files[i] = {host: task.grid.hostname, path: path};
+    size = task.lib.fs.statSync(path);
+    task.files[i] = {host: task.grid.hostname, path: path, size: size};
   }
   done();
 };

--- a/lib/worker-local.js
+++ b/lib/worker-local.js
@@ -68,6 +68,7 @@ function runTask(msg) {
   task.run(function (result) {
     delete msg.req.args;
     msg.result = result;
+    msg.result.workerId = workerId;
     process.send(msg);
   });
 }


### PR DESCRIPTION
Insuring constant ordering of partitions in the combine stage of aggregate despite unordered partial results from workers allows to fix collect, which was serialized, and all actions depending on order, aka sorting, take, etc.

Now traces show which worker process which partition. Much more detailed shuffle informations are now displayed.