### PR TITLE
Simplify top and take actions, and fix out of memory errors for large datasets.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -110,7 +110,12 @@ Consumer.prototype._transform = function (chunk, encoding, done) {
     return this.streams[streamid].write(chunk.slice(9), encoding, done);
   }
 
-  var msg = JSON.parse(chunk.slice(8));
+  try {
+    var msg = JSON.parse(chunk.slice(8));
+  } catch (err) {
+    console.err('Error parsing chunk:', chunk.slice(8));
+    throw err;
+  }
 
   if (msg.ufrom && !this.client.hostId[msg.ufrom])
     this.client.hostId[msg.ufrom] = msg.from;

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -199,12 +199,9 @@ function Context(args) {
 
     function runShuffleStage(stage, done) {
       findNodes(stage, function(nodes) {
-        var pid = 0, tasks = [], i, j;
+        var pid = 0, tasks = [], i, j, node;
+        var index = 0, busy = 0, complete = 0, totalFiles = 0, totalSize = 0;
         stage.shufflePartitions = {};
-        var index = 0;
-        var busy = 0;
-        var complete = 0;
-        var node;
 
         for (i = 0; i < stage.dependencies.length; i++) {
           node = stage.dependencies[i];
@@ -225,7 +222,6 @@ function Context(args) {
         }
 
         function runNext() {
-          var totalFiles = 0, totalSize = 0;
           while (busy < nworker && index < tasks.length) {
             busy++;
             self.runTask(tasks[index++], function (err, res, task) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -246,12 +246,9 @@ function SkaleContext(arg) {
 
     function runShuffleStage(stage, done) {
       findNodes(stage, function(nodes) {
-        var pid = 0, tasks = [], i, j;
+        var pid = 0, tasks = [], i, j, node;
+        var index = 0, busy = 0, complete = 0, totalFiles = 0, totalSize = 0;
         stage.shufflePartitions = {};
-        var index = 0;
-        var busy = 0;
-        var complete = 0;
-        var node;
 
         for (i = 0; i < stage.dependencies.length; i++) {
           node = stage.dependencies[i];
@@ -271,7 +268,6 @@ function SkaleContext(arg) {
         }
 
         function runNext() {
-          var totalFiles = 0, totalSize = 0;
           while (busy < nworker && index < tasks.length) {
             busy++;
             self.runTask(tasks[index++], function (err, res, task) {

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -340,8 +340,8 @@ Dataset.prototype.take = thenify(function (N, done) {
 });
 
 Dataset.prototype.top = thenify(function (N, done) {
-  var reducer = function (a, b, opt, wc) {a.push(b); return (a.length > opt._max) ? a.slice(1) : a;};
-  var combiner = function (a, b, opt) {return ((a.length < opt._max) ? b.concat(a) : a).slice(-opt._max);}
+  var reducer = function (a, b, opt) {a.push(b); return (a.length > opt._max) ? a.slice(1) : a;};
+  var combiner = function (a, b, opt) {return ((a.length < opt._max) ? b.concat(a) : a).slice(-opt._max);};
   return this.aggregate(reducer, combiner, [], {_max: N, _maxbusy: 1, _lifo: true}, done);
 });
 

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -333,6 +333,18 @@ Dataset.prototype.save = thenify(function (path, options, done) {
   return this.aggregate(reducer, function(){}, '', opt, done);
 });
 
+Dataset.prototype.take = thenify(function (N, done) {
+  var reducer = function (a, b, opt) {if (a.length < opt._max) a.push(b); return a;};
+  var combiner = function (a, b, opt) {return ((a.length < opt._max) ? a.concat(b) : a).slice(0, opt._max);};
+  return this.aggregate(reducer, combiner, [], {_max: N, _maxbusy: 1}, done);
+});
+
+Dataset.prototype.top = thenify(function (N, done) {
+  var reducer = function (a, b, opt, wc) {a.push(b); return (a.length > opt._max) ? a.slice(1) : a;};
+  var combiner = function (a, b, opt) {return ((a.length < opt._max) ? b.concat(a) : a).slice(-opt._max);}
+  return this.aggregate(reducer, combiner, [], {_max: N, _maxbusy: 1, _lifo: true}, done);
+});
+
 Dataset.prototype.first = thenify(function (done) {
   return this.take(1, function (err, res) {
     if (res) done(err, res[0]);
@@ -340,71 +352,51 @@ Dataset.prototype.first = thenify(function (done) {
   });
 });
 
-Dataset.prototype.take = thenify(function (N, done) {
-  var reducer = function (a, b) {a.push(b); return a;};
-  var combiner = function (a, b) {return a.concat(b);};
-  var init = [], action = {args: [], src: reducer, init: init, opt: {}}, self = this;
-
-  return this.sc.runJob({}, this, action, function (job, tasks) {
-    var result = JSON.parse(JSON.stringify(init)), cnt = 0;
-
-    function taskDone(err, res) {
-      result = combiner(result, res.data);
-      if (++cnt < tasks.length && result.length < N) self.sc.runTask(tasks[cnt], taskDone);
-      else done(err, result.slice(0, N));
-    }
-
-    self.sc.runTask(tasks[cnt], taskDone);
-  });
-});
-
-Dataset.prototype.top = thenify(function (N, done) {
-  var reducer = function (a, b) {a.push(b); return a;};
-  var combiner = function (a, b) {return b.concat(a);};
-  var init = [], action = {args: [], src: reducer, init: init, opt: {}}, self = this;
-
-  return this.sc.runJob({}, this, action, function (job, tasks) {
-    var result = JSON.parse(JSON.stringify(init)), cnt = tasks.length - 1;
-
-    function taskDone(err, res) {
-      result = combiner(result, res.data);
-      if (--cnt >= 0 || result.length < N) self.sc.runTask(tasks[cnt], taskDone);
-      else done(err, result.slice(-N));
-    }
-
-    self.sc.runTask(tasks[cnt], taskDone);
-  });
-});
-
+// Aggregate is the main action. All others are implemented on top of it.
+// The following internal option flags drive its behaviour:
+// * _max: maximum number of dataset entries to combine. Set by take and top.
+//    this allows to skip useless processing once result is obtained.
+// * _maxbusy: maximum number of parallel aggregate tasks. Set to 1 by take and top.
+// * _lifo: enable partition processing from last to first. Set by top.
+//
 Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, done) {
-  opt = opt || {}; var action = {args: [], src: reducer, init: init,
-  opt: opt}, self = this;
+  opt = opt || {};
+  var action = {args: [], src: reducer, init: init, opt: opt};
+  var self = this;
+  var maxbusy = opt._maxbusy || this.sc.worker.length;  // set to 1 for take/top
 
   if (arguments.length < 5) done = opt;
 
   return this.sc.runJob(opt, this, action, function (job, tasks) {
-    var tmp = [];   // Pending tasks results waiting for combine
-    var result = JSON.parse(JSON.stringify(init));
-    var nworker = self.sc.worker.length;
-    var index = 0;
-    var busy = 0;       // Number of busy tasks, use to schedule as many tasks as workers
+    var tmp = [];                                     // Pending tasks results waiting for combine
+    var result = JSON.parse(JSON.stringify(init));    // reducer/combiner result init
+    var index = opt._lifo ? tasks.length - 1 : 0;     // start from 0, or last if top action
+    var lastIndex = opt._lifo ? 0 : tasks.length;     // 0 for top action
+    var incr = opt._lifo ? -1 : 1;
+    var busy = 0;                                     // Number of busy tasks
     var complete = 0;
     var error;
 
     function runNext() {
-      while (busy < nworker && index < tasks.length) {
-        busy++;
-        self.sc.runTask(tasks[index++], function (err, res, task) {
-          tmp[task.pid] = res.data;
+      while (busy < maxbusy && index !== lastIndex) {
+        self.sc.runTask(tasks[index], function (err, res, task) {
+          if (err) {
+            // FIXME: should handle task re-submit here for fault tolerance
+            console.error('ERROR: aggregate partition', task.pid);
+          }
+          var i, stop = opt._max && res.data.length >= opt._max;
+          var tmpIndex = opt._lifo ? tasks.length - 1 - task.pid : task.pid;
+          tmp[tmpIndex] = res.data;
           complete++;
           busy--;
           self.sc.log('part', task.pid, 'from worker-' + res.workerId, '(' + complete + '/' + tasks.length + ')');
-          if (complete < tasks.length) return runNext();
-          self.sc.log('result stage done');
-          for (var i = 0; i < tmp.length; i++)
+          if (!stop && complete < tasks.length) return runNext();
+          for (i = 0; i < tmp.length; i++)
             result = combiner(result, tmp[i], opt);
           done(error, result);
         });
+        index += incr;
+        busy++;
       }
     }
 
@@ -682,7 +674,7 @@ TextS3File.prototype.iterate = function (task, p, pipeline, done) {
 
   task.log('stream s3', this.bucket, this.path);
   if (this.options.parquet || this.path.slice(-8) === '.parquet')
-    return parquetStream(rs, this.path, task, pipeline, done); 
+    return parquetStream(rs, this.path, task, pipeline, done);
 
   if (this.path.slice(-3) === '.gz')
     rs = rs.pipe(task.lib.zlib.createGunzip({chunkSize: 65536}));

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -336,13 +336,13 @@ Dataset.prototype.save = thenify(function (path, options, done) {
 Dataset.prototype.take = thenify(function (N, done) {
   var reducer = function (a, b, opt) {if (a.length < opt._max) a.push(b); return a;};
   var combiner = function (a, b, opt) {return ((a.length < opt._max) ? a.concat(b) : a).slice(0, opt._max);};
-  return this.aggregate(reducer, combiner, [], {_max: N, _maxbusy: 1}, done);
+  return this.aggregate(reducer, combiner, [], {_max: N, _maxBusy: 1}, done);
 });
 
 Dataset.prototype.top = thenify(function (N, done) {
   var reducer = function (a, b, opt) {a.push(b); return (a.length > opt._max) ? a.slice(1) : a;};
   var combiner = function (a, b, opt) {return ((a.length < opt._max) ? b.concat(a) : a).slice(-opt._max);};
-  return this.aggregate(reducer, combiner, [], {_max: N, _maxbusy: 1, _lifo: true}, done);
+  return this.aggregate(reducer, combiner, [], {_max: N, _maxBusy: 1, _lifo: true}, done);
 });
 
 Dataset.prototype.first = thenify(function (done) {
@@ -356,14 +356,13 @@ Dataset.prototype.first = thenify(function (done) {
 // The following internal option flags drive its behaviour:
 // * _max: maximum number of dataset entries to combine. Set by take and top.
 //    this allows to skip useless processing once result is obtained.
-// * _maxbusy: maximum number of parallel aggregate tasks. Set to 1 by take and top.
+// * _maxBusy: maximum number of parallel aggregate tasks. Set to 1 by take and top.
 // * _lifo: enable partition processing from last to first. Set by top.
 //
 Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, done) {
   opt = opt || {};
   var action = {args: [], src: reducer, init: init, opt: opt};
   var self = this;
-  var maxbusy = opt._maxbusy || this.sc.worker.length;  // set to 1 for take/top
 
   if (arguments.length < 5) done = opt;
 
@@ -372,13 +371,14 @@ Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, do
     var result = JSON.parse(JSON.stringify(init));    // reducer/combiner result init
     var index = opt._lifo ? tasks.length - 1 : 0;     // start from 0, or last if top action
     var lastIndex = opt._lifo ? 0 : tasks.length;     // 0 for top action
+    var maxBusy = opt._maxBusy || self.sc.worker.length;  // set to 1 for take/top
     var incr = opt._lifo ? -1 : 1;
     var busy = 0;                                     // Number of busy tasks
     var complete = 0;
     var error;
 
     function runNext() {
-      while (busy < maxbusy && index !== lastIndex) {
+      while (busy < maxBusy && index !== lastIndex) {
         self.sc.runTask(tasks[index], function (err, res, task) {
           if (err) {
             // FIXME: should handle task re-submit here for fault tolerance
@@ -829,6 +829,7 @@ TextDir.prototype.getPartitions = function (done) {
 
 TextDir.prototype.iterate = function (task, p, pipeline, done) {
   var path = this.dir + this.partitions[p].path;
+  task.log('stream local file', path);
   if (this.options.parquet || path.slice(-8) === '.parquet')
     return parquetIterate(path, pipeline, done);
   var tail = '';


### PR DESCRIPTION
All the actions (functions returning results out of skale) are now implemented on top of aggregate, which is now the only core action. Code is simpler and more robust, and it paves the way for handling post-shuffle task abort only in one place.