### PR TITLE
aggregateByKey, coGroup: performance improvements

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -174,13 +174,13 @@ function runWorker(host, port) {
     var task = parseTask(msg.data.args);
     basedir = task.basedir;
     // set worker side dependencies
-    task.workerId = grid.host.uuid;
+    task.workerId = 'w' + grid.id;
     task.mm = mm;
     task.log = log;
     task.lib = {AWS: AWS, azure: azure, sizeOf: sizeOf, fs: fs, readSplit: readSplit, Lines: Lines, task: task, mkdirp: mkdirp, parquet: parquet, url: url, uuid: uuid, zlib: zlib};
     task.grid = grid;
     task.run(function(result) {
-      result.workerId = 'g' + grid.id;
+      result.workerId = task.workerId;
       grid.reply(msg, null, result);
     });
   }

--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -161,8 +161,8 @@ function Context(args) {
       task.env = this.env;
     }
 
-    this.worker[wid].ntask++;
     var str = serialize(task);
+    this.worker[wid].ntask++;
     //log('task size for worker ' + wid + ':', str.length);
     //log('task', str);
     if (str.length > 1000000) {

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -3,10 +3,10 @@
 'use strict';
 
 var fs = require('fs');
-var path = require('path');
 var url = require('url');
-var util = require('util');
 var stream = require('stream');
+var inherits = require('util').inherits;
+var basename = require('path').basename;
 
 var thenify = require('thenify').withCallback;
 var uuid = require('uuid');
@@ -94,7 +94,7 @@ Dataset.prototype.join = function (other) {
 Dataset.prototype.leftOuterJoin = function (other) {
   return this.coGroup(other).flatMapValues(function (v) {
     var res = [], i, j;
-    if (v[1].length == 0) {
+    if (v[1].length === 0) {
       for (i in v[0]) res.push([v[0][i], null]);
     } else {
       for (i in v[0])
@@ -107,7 +107,7 @@ Dataset.prototype.leftOuterJoin = function (other) {
 Dataset.prototype.rightOuterJoin = function (other) {
   return this.coGroup(other).flatMapValues(function (v) {
     var res = [], i, j;
-    if (v[0].length == 0) {
+    if (v[0].length === 0) {
       for (i in v[1]) res.push([null, v[1][i]]);
     } else {
       for (i in v[0])
@@ -140,7 +140,7 @@ Dataset.prototype.subtract = function (other) {
   var b = other.map(mapper).reduceByKey(reducer, 0);
   return a.coGroup(b).flatMap(function (a) {
     var res = [];
-    if (a[1][0].length && (a[1][1].length == 0))
+    if (a[1][0].length && (a[1][1].length === 0))
       for (var i = 0; i < a[1][0][0]; i++) res.push(a[0]);
     return res;
   });
@@ -439,7 +439,7 @@ Dataset.prototype.forEach = thenify(function (eacher, opt, done) {
 });
 
 Dataset.prototype.getPartitions = function (done) {
-  if (this.partitions == undefined) {
+  if (this.partitions === undefined) {
     this.partitions = {};
     var cnt = 0;
     for (var i = 0; i < this.dependencies.length; i++) {
@@ -474,9 +474,9 @@ Partition.prototype.transform = function (context, data) {
   // Periodically check/update available memory, and evict partition
   // if necessary. In this case it will be recomputed if required by
   // a future action.
-  if (this.count++ == 9999) {
+  if (this.count++ === 9999) {
     this.count = 0;
-    if (this.bsize == 0) this.bsize = this.mm.sizeOf(this.data);
+    if (this.bsize === 0) this.bsize = this.mm.sizeOf(this.data);
     this.tsize += this.bsize;
     this.mm.storageMemory += this.bsize;
     if (this.mm.storageFull()) {
@@ -513,7 +513,7 @@ function Source(sc, N, getItem, args, npart) {
   this.args = args;
   this.type = 'Source';
 }
-util.inherits(Source, Dataset);
+inherits(Source, Dataset);
 
 Source.prototype.iterate = function (task, p, pipeline, done) {
   var buffer, i, index = this.bases[p], n = this.sizes[p];
@@ -562,7 +562,7 @@ function range(sc, start, end, step, P) {
 function Obj2line() {
   stream.Transform.call(this, {objectMode: true});
 }
-util.inherits(Obj2line, stream.Transform);
+inherits(Obj2line, stream.Transform);
 
 Obj2line.prototype._transform = function (chunk, encoding, done) {
   done(null, JSON.stringify(chunk) + '\n');
@@ -576,12 +576,12 @@ function Stream(sc, stream, type) { // type = 'line' ou 'object'
   var dataset = sc.textFile(targetFile);
 
   dataset.watched = true;         // notify skale to wait for file before launching
-  dataset.parse = type == 'object';
+  dataset.parse = type === 'object';
   out.on('close', function () {
     fs.renameSync(tmpFile, targetFile);
     dataset.watched = false;
   });
-  if (type == 'object')
+  if (type === 'object')
     stream.pipe(new Obj2line()).pipe(out);
   else
     stream.pipe(out);
@@ -612,7 +612,7 @@ function ParquetFile(sc, file) {
   this.type = 'ParquetFile';
 }
 
-util.inherits(ParquetFile, Dataset);
+inherits(ParquetFile, Dataset);
 
 ParquetFile.prototype.getPartitions = function (done) {
   this.partitions = {0: new Partition(this.id, 0)};
@@ -632,7 +632,7 @@ function GzipFile(sc, file) {
   this.type = 'GzipFile';
 }
 
-util.inherits(GzipFile, Dataset);
+inherits(GzipFile, Dataset);
 
 GzipFile.prototype.getPartitions = function (done) {
   this.partitions = {0: new Partition(this.id, 0)};
@@ -656,7 +656,7 @@ function TextS3File(sc, file, options) {
   this.options = options || {};
 }
 
-util.inherits(TextS3File, Dataset);
+inherits(TextS3File, Dataset);
 
 TextS3File.prototype.getPartitions = function (done) {
   this.partitions = {0: new Partition(this.id, 0)};
@@ -692,7 +692,7 @@ function TextAzure(sc, dir, options) {
   this.options.azure = this.options.azure || {};
 }
 
-util.inherits(TextAzure, Dataset);
+inherits(TextAzure, Dataset);
 
 TextAzure.prototype.getPartitions = function (done) {
   var self = this;
@@ -834,7 +834,7 @@ function TextS3Dir(sc, dir, options) {
   this.options.s3.signatureVersion = this.options.s3.signatureVersion || 'v4';
 }
 
-util.inherits(TextS3Dir, Dataset);
+inherits(TextS3Dir, Dataset);
 
 TextS3Dir.prototype.getPartitions = function (done) {
   var self = this;
@@ -906,7 +906,7 @@ function TextDir(sc, dir, options) {
   this.options = options || {};
 }
 
-util.inherits(TextDir, Dataset);
+inherits(TextDir, Dataset);
 
 TextDir.prototype.getPartitions = function (done) {
   var self = this;
@@ -947,7 +947,7 @@ function TextFile(sc, file, nPartitions) {
   this.basedir = sc.basedir;
 }
 
-util.inherits(TextFile, Dataset);
+inherits(TextFile, Dataset);
 
 TextFile.prototype.getPartitions = function (done) {
   var self = this;
@@ -955,7 +955,7 @@ TextFile.prototype.getPartitions = function (done) {
   function getSplits() {
     var u = url.parse(self.file);
 
-    if ((u.protocol == 'hdfs:') && u.slashes && u.hostname && u.port)
+    if ((u.protocol === 'hdfs:') && u.slashes && u.hostname && u.port)
       splitHDFSFile(u.path, self.nSplit, mapLogicalSplit);
     else
       splitLocalFile(u.path, self.nSplit, mapLogicalSplit);
@@ -972,7 +972,7 @@ TextFile.prototype.getPartitions = function (done) {
 
   if (this.watched) {
     var watcher = fs.watch(self.basedir + 'stream', function (event, filename) {
-      if ((event == 'rename') && (filename == path.basename(self.file))) {
+      if ((event === 'rename') && (filename === basename(self.file))) {
         watcher.close();  // stop watching directory
         getSplits();
       }
@@ -1011,7 +1011,7 @@ function Map(parent, mapper, args) {
   this.type = 'Map';
 }
 
-util.inherits(Map, Dataset);
+inherits(Map, Dataset);
 
 Map.prototype.transform = function map(context, data) {
   var tmp = [];
@@ -1027,7 +1027,7 @@ function FlatMap(parent, mapper, args) {
   this.type = 'FlatMap';
 }
 
-util.inherits(FlatMap, Dataset);
+inherits(FlatMap, Dataset);
 
 FlatMap.prototype.transform = function flatmap(context, data) {
   var tmp = [];
@@ -1043,7 +1043,7 @@ function MapValues(parent, mapper, args) {
   this.type = 'MapValues';
 }
 
-util.inherits(MapValues, Dataset);
+inherits(MapValues, Dataset);
 
 MapValues.prototype.transform = function (context, data) {
   var tmp = [];
@@ -1059,7 +1059,7 @@ function FlatMapValues(parent, mapper, args) {
   this.type = 'FlatMapValues';
 }
 
-util.inherits(FlatMapValues, Dataset);
+inherits(FlatMapValues, Dataset);
 
 FlatMapValues.prototype.transform = function (context, data) {
   var tmp = [];
@@ -1077,7 +1077,7 @@ function Filter(parent, filter, args) {
   this.type = 'Filter';
 }
 
-util.inherits(Filter, Dataset);
+inherits(Filter, Dataset);
 
 Filter.prototype.transform = function (context, data) {
   var tmp = [];
@@ -1129,7 +1129,7 @@ function Sample(parent, withReplacement, frac, seed) {
   this.type = 'Sample';
 }
 
-util.inherits(Sample, Dataset);
+inherits(Sample, Dataset);
 
 Sample.prototype.transform = function (context, data) {
   var tmp = [], i, j;
@@ -1148,7 +1148,7 @@ function Union(sc, parents) {
   this.type = 'Union';
 }
 
-util.inherits(Union, Dataset);
+inherits(Union, Dataset);
 
 Union.prototype.transform = function (context, data) {return data;};
 
@@ -1164,10 +1164,10 @@ function AggregateByKey(sc, dependencies, reducer, combiner, init, args) {
   this.type = 'AggregateByKey';
 }
 
-util.inherits(AggregateByKey, Dataset);
+inherits(AggregateByKey, Dataset);
 
 AggregateByKey.prototype.getPartitions = function (done) {
-  if (this.partitions == undefined) {
+  if (this.partitions === undefined) {
     var P = 0, i;
     this.partitions = {};
     for (i = 0; i < this.dependencies.length; i++)
@@ -1193,7 +1193,7 @@ AggregateByKey.prototype.transform = function (context, data) {
 AggregateByKey.prototype.spillToDisk = function (task, done) {
   var i, isLeft, str, key, path, size;
 
-  if (this.dependencies.length > 1) {                 // COGROUP
+  if (this.dependencies.length > 1) {   // COGROUP
     isLeft = (this.shufflePartitions[task.pid].parentDatasetId == this.dependencies[0].id);
     for (i = 0; i < this.nPartitions; i++) {
       str = '';
@@ -1283,10 +1283,10 @@ function Cartesian(sc, dependencies) {
   this.type = 'Cartesian';
 }
 
-util.inherits(Cartesian, Dataset);
+inherits(Cartesian, Dataset);
 
 Cartesian.prototype.getPartitions = function (done) {
-  if (this.partitions == undefined) {
+  if (this.partitions === undefined) {
     this.pleft = this.dependencies[0].nPartitions;
     this.pright =  this.dependencies[1].nPartitions;
     var P = this.pleft * this.pright;
@@ -1354,16 +1354,16 @@ function SortBy(sc, dependencies, keyFunc, ascending, numPartitions) {
   this.shuffling = true;
   this.executed = false;
   this.keyFunc = keyFunc;
-  this.ascending = (ascending == undefined) ? true : ascending;
+  this.ascending = (ascending === undefined) ? true : ascending;
   this.buffer = [];
   this.numPartitions = numPartitions;
   this.type = 'SortBy';
 }
 
-util.inherits(SortBy, Dataset);
+inherits(SortBy, Dataset);
 
 SortBy.prototype.getPartitions = function (done) {
-  if (this.partitions == undefined) {
+  if (this.partitions === undefined) {
     var P = Math.max(this.numPartitions || 1, this.dependencies[0].nPartitions);
 
     this.partitions = {};
@@ -1377,7 +1377,7 @@ SortBy.prototype.getPartitions = function (done) {
 SortBy.prototype.transform = function (context, data) {
   for (var i = 0; i < data.length; i++) {
     var pid = this.partitioner.getPartitionIndex(this.keyFunc(data[i]));
-    if (this.buffer[pid] == undefined) this.buffer[pid] = [];
+    if (this.buffer[pid] === undefined) this.buffer[pid] = [];
     this.buffer[pid].push(data[i]);
   }
 };
@@ -1422,7 +1422,7 @@ SortBy.prototype.iterate = function (task, p, pipeline, done) {
   }
 
   function processDone() {
-    if (++cnt == files.length) {
+    if (++cnt === files.length) {
       cbuffer.sort(compare);
       for (var i = 0; i < cbuffer.length; i++) {
         var buffer = [cbuffer[i]];
@@ -1449,10 +1449,10 @@ function PartitionBy(sc, dependencies, partitioner) {
   this.type = 'PartitionBy';
 }
 
-util.inherits(PartitionBy, Dataset);
+inherits(PartitionBy, Dataset);
 
 PartitionBy.prototype.getPartitions = function (done) {
-  if (this.partitions == undefined) {
+  if (this.partitions === undefined) {
     var P = this.partitioner.numPartitions;
     this.partitions = {};
     this.nPartitions = P;
@@ -1465,7 +1465,7 @@ PartitionBy.prototype.getPartitions = function (done) {
 PartitionBy.prototype.transform = function (context, data) {
   for (var i = 0; i < data.length; i++) {
     var pid = this.partitioner.getPartitionIndex(data[i][0]);
-    if (this.buffer[pid] == undefined) this.buffer[pid] = [];
+    if (this.buffer[pid] === undefined) this.buffer[pid] = [];
     this.buffer[pid].push(data[i]);
   }
 };
@@ -1510,7 +1510,7 @@ PartitionBy.prototype.iterate = function (task, p, pipeline, done) {
   }
 
   function processDone() {
-    if (++cnt == files.length) {
+    if (++cnt === files.length) {
       for (var i = 0; i < cbuffer.length; i++) {
         var buffer = [cbuffer[i]];
         for (var t = 0; t < pipeline.length; t++)

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -83,9 +83,9 @@ Dataset.prototype.sortByKey = function (ascending, numPartitions) {
 
 Dataset.prototype.join = function (other) {
   return this.coGroup(other).flatMapValues(function (v) {
-    var res = [];
-    for (var i in v[0])
-      for (var j in v[1])
+    var res = [], i, j;
+    for (i in v[0])
+      for (j in v[1])
         res.push([v[0][i], v[1][j]]);
     return res;
   });
@@ -386,7 +386,7 @@ Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, do
 
   return this.sc.runJob(opt, this, action, function (job, tasks) {
     var tmp = [];                                     // Pending tasks results waiting for combine
-    var result = JSON.parse(JSON.stringify(init));    // reducer/combiner result init
+    var result = deepCopy(init);                      // reducer/combiner result init
     var index = opt._lifo ? tasks.length - 1 : 0;     // start from 0, or last if top action
     var lastIndex = opt._lifo ? 0 : tasks.length;     // 0 for top action
     var maxBusy = opt._maxBusy || self.sc.worker.length;  // set to 1 for take/top
@@ -1160,7 +1160,7 @@ function AggregateByKey(sc, dependencies, reducer, combiner, init, args) {
   this.args = args;
   this.shuffling = true;
   this.executed = false;
-  this.buffer = [];
+  this.buffer = {};
   this.type = 'AggregateByKey';
 }
 
@@ -1180,73 +1180,80 @@ AggregateByKey.prototype.getPartitions = function (done) {
 };
 
 AggregateByKey.prototype.transform = function (context, data) {
-  var i, key, pid;
+  var i, d, key, buf = this.buffer, acc;
   for (i = 0; i < data.length; i++) {
-    key = JSON.stringify(data[i][0]);
-    pid = this.partitioner.getPartitionIndex(key);
-    if (this.buffer[pid] === undefined) this.buffer[pid] = {};
-    if (this.buffer[pid][key] === undefined) this.buffer[pid][key] = JSON.parse(JSON.stringify(this.init));
-    this.buffer[pid][key] = this.reducer(this.buffer[pid][key], data[i][1], this.args, this.global);
+    d = data[i];
+    key = JSON.stringify(d[0]);
+    acc = (key in buf) ? buf[key] : deepCopy(this.init);
+    buf[key] = this.reducer(acc, d[1], this.args, this.global);
   }
 };
 
 AggregateByKey.prototype.spillToDisk = function (task, done) {
-  var i, isLeft, str, key, path, size;
+  var i, isLeft, key, pid, buf = this.buffer, plen = this.nPartitions;
+  var str = Array(plen).fill('');
+  var size = Array(plen).fill(0);
+  var path = task.basedir + 'shuffle/' + task.workerId + '-' + task.datasetId + '-';
 
   if (this.dependencies.length > 1) {   // COGROUP
     isLeft = (this.shufflePartitions[task.pid].parentDatasetId == this.dependencies[0].id);
-    for (i = 0; i < this.nPartitions; i++) {
-      str = '';
-      path = task.basedir + 'shuffle/' + task.lib.uuid.v4();
-      if (isLeft) {
-        for (key in this.buffer[i]) {
-          str += '[' + key + ',' + '[' + JSON.stringify(this.buffer[i][key]) + ',[]]]\n';
-          if (str.length >= 65536) {
-            task.lib.fs.appendFileSync(path, str);
-            str = '';
-          }
-        }
-      } else {
-        for (key in this.buffer[i]) {
-          str += '[' + key + ',' + '[[],' + JSON.stringify(this.buffer[i][key]) + ']]\n';
-          if (str.length >= 65536) {
-            task.lib.fs.appendFileSync(path, str);
-            str = '';
-          }
+    if (isLeft) {
+      for (key in buf) {
+        pid = hash(key) % plen;
+        str[pid] += '[' + key + ',' + '[' + JSON.stringify(buf[key]) + ',[]]]\n';
+        if (str[pid].length >= 65536) {
+          task.lib.fs.appendFileSync(path + pid, str[pid]);
+          size[pid] += str[pid].length;
+          str[pid] = '';
         }
       }
-      task.lib.fs.appendFileSync(path, str);
-      size = task.lib.fs.statSync(path).size;
-      task.files[i] = {host: task.grid.hostname, path: path, size: size};
+    } else {
+      for (key in buf) {
+        pid = hash(key) % plen;
+        str[pid] += '[' + key + ',' + '[[],' + JSON.stringify(buf[key]) + ']]\n';
+        if (str[pid].length >= 65536) {
+          task.lib.fs.appendFileSync(path + pid, str[pid]);
+          size[pid] += str[pid].length;
+          str[pid] = '';
+        }
+      }
     }
   } else {                              // AGGREGATE BY KEY
-    for (i = 0; i < this.nPartitions; i++) {
-      str = '';
-      path = task.basedir + 'shuffle/' + task.lib.uuid.v4();
-      for (key in this.buffer[i]) {
-        str += '[' + key +  ',' + JSON.stringify(this.buffer[i][key]) + ']\n';
-        if (str.length >= 65536) {
-          task.lib.fs.appendFileSync(path, str);
-          str = '';
-        }
+    for (key in buf) {
+      pid = hash(key) % plen;
+      str[pid] += '[' + key + ',' + JSON.stringify(buf[key]) + ']\n';
+      if (str[pid].length >= 65536) {
+        task.lib.fs.appendFileSync(path + pid, str[pid]);
+        size[pid] += str[pid].length;
+        str[pid] = '';
       }
-      task.lib.fs.appendFileSync(path, str);
-      size = task.lib.fs.statSync(path).size;
-      task.files[i] = {host: task.grid.hostname, path: path, size: size};
     }
+  }
+  for (i = 0; i < plen; i++) {
+    //task.log('pre-shuffle path:', path + i);
+    task.lib.fs.appendFileSync(path + i, str[i]);
+    size[i] += str[i].length;
+    task.files[i] = {host: task.grid.hostname, path: path + i, size: size[i]};
   }
   done();
 };
 
 AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
-  var self = this, cbuffer = {}, cnt = 0, files = [];
+  //var self = this, cbuffer = {}, cnt = 0, files = [];
+  var self = this, i, cbuffer = {}, cnt = 0, file, files = [], shuffleFiles = {};
 
-  for (var i = 0; i < self.nShufflePartitions; i++)
-    files.push(self.shufflePartitions[i].files[p]);
+  for (i = 0; i < self.nShufflePartitions; i++) {
+    file = self.shufflePartitions[i].files[p];
+    if (!(file.path in shuffleFiles)) {
+      files.push(file);
+      shuffleFiles[file.path] = true;
+    }
+  }
 
   processShuffleFile(files[cnt], processDone);
 
   function processShuffleFile(file, done) {
+    //task.log('processShuffleFile', p, file);
     //task.log('processShuffleFile', p, file.path);
     var lines = new task.lib.Lines();
     task.getReadStream(file, undefined, function (err, stream) {
@@ -1556,16 +1563,31 @@ function HashPartitioner(numPartitions) {
   this.type = 'HashPartitioner';
 }
 
-HashPartitioner.prototype.hash = function hash(s) {
+HashPartitioner.prototype.hash = hash;
+
+function hash(s) {
   var i, h = 0;
   for (i = 0; i < s.length; i++)
     h = (h << 5) - h + s.charCodeAt(i);
   return h >>> 0;   // Convert to unsigned
-};
+}
 
 HashPartitioner.prototype.getPartitionIndex = function (data) {
   return this.hash(data) % this.numPartitions;
 };
+
+function deepCopy(o) {
+  var i, n;
+  if (typeof o !== 'object' || !o) return o;
+  if (o.constructor === Array) {
+    n = new Array(o.length);
+    for (i = 0; i < o.length; i++) n[i] = deepCopy(o[i]);
+    return n;
+  }
+  n = {};
+  for (i in o) n[i] = deepCopy(o[i]);
+  return n;
+}
 
 module.exports = {
   Dataset: Dataset,


### PR DESCRIPTION
A deepCopy function is provided to duplicate objects, 20 times faster
than JSON.parse(JSON.stringify(o)).

Key hashcodes are now computed only once per key, during spillToDisk()
rather than for each entry in transform() aggregation callback.

Shuffle file nomenclature is changed from random uuid to
workerId-StageId-PartitionId, in order to drastically reduce the nummber
of shuffle files (from square of partitions to partitions time workers).

A performance increase of about 20% is seen for intensive reduceByKey +
Join workloads.