### PR TITLE
AggregateByKey: faster processing of shuffle files

### DIFF
--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -1200,7 +1200,7 @@ AggregateByKey.prototype.spillToDisk = function (task, done) {
     if (isLeft) {
       for (key in buf) {
         pid = hash(key) % plen;
-        str[pid] += '[' + key + ',' + '[' + JSON.stringify(buf[key]) + ',[]]]\n';
+        str[pid] += key + '\n[' + JSON.stringify(buf[key]) + ',[]]\n';
         if (str[pid].length >= 65536) {
           task.lib.fs.appendFileSync(path + pid, str[pid]);
           size[pid] += str[pid].length;
@@ -1210,7 +1210,7 @@ AggregateByKey.prototype.spillToDisk = function (task, done) {
     } else {
       for (key in buf) {
         pid = hash(key) % plen;
-        str[pid] += '[' + key + ',' + '[[],' + JSON.stringify(buf[key]) + ']]\n';
+        str[pid] += key + '\n[[],' + JSON.stringify(buf[key]) + ']\n';
         if (str[pid].length >= 65536) {
           task.lib.fs.appendFileSync(path + pid, str[pid]);
           size[pid] += str[pid].length;
@@ -1221,7 +1221,7 @@ AggregateByKey.prototype.spillToDisk = function (task, done) {
   } else {                              // AGGREGATE BY KEY
     for (key in buf) {
       pid = hash(key) % plen;
-      str[pid] += '[' + key + ',' + JSON.stringify(buf[key]) + ']\n';
+      str[pid] += key + '\n' + JSON.stringify(buf[key]) + '\n';
       if (str[pid].length >= 65536) {
         task.lib.fs.appendFileSync(path + pid, str[pid]);
         size[pid] += str[pid].length;
@@ -1239,7 +1239,6 @@ AggregateByKey.prototype.spillToDisk = function (task, done) {
 };
 
 AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
-  //var self = this, cbuffer = {}, cnt = 0, files = [];
   var self = this, i, cbuffer = {}, cnt = 0, file, files = [], shuffleFiles = {};
 
   for (i = 0; i < self.nShufflePartitions; i++) {
@@ -1253,20 +1252,32 @@ AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
   processShuffleFile(files[cnt], processDone);
 
   function processShuffleFile(file, done) {
-    //task.log('processShuffleFile', p, file);
-    //task.log('processShuffleFile', p, file.path);
-    var lines = new task.lib.Lines();
     task.getReadStream(file, undefined, function (err, stream) {
-      stream.pipe(lines);
+      var tail = '', lastk;
+
+      // Input format: interleaving of key lines and value lines
+      stream.on('data', function (buf) {
+        var data = tail + buf.toString(), lines = data.split('\n'), len, i = 0, k, v;
+        tail = lines.pop();
+        len = lastk ? lines.unshift(lastk) : lines.length;
+        lastk = (len & 1) ? lines.pop() : undefined;
+        while (i < lines.length) {
+          k = lines[i++];
+          v = JSON.parse(lines[i++]);
+          if (k in cbuffer) cbuffer[k] = self.combiner(cbuffer[k], v, self.args, self.global);
+          else cbuffer[k] = v;
+        }
+      });
+      stream.on('end', function () {
+        var v;
+        if (lastk && tail.length) {
+          v = JSON.parse(tail);
+          if (lastk in cbuffer) cbuffer[lastk] = self.combiner(cbuffer[lastk], v, self.args, self.global);
+          else cbuffer[lastk] = v;
+        }
+        done();
+      });
     });
-    lines.on('data', function (linev) {
-      for (var i = 0; i < linev.length; i++) {
-        var data = JSON.parse(linev[i]), key = JSON.stringify(data[0]);
-        if (cbuffer[key] === undefined) cbuffer[key] = data[1];
-        else cbuffer[key] = self.combiner(cbuffer[key], data[1], self.args, self.global);
-      }
-    });
-    lines.on('end', done);
   }
 
   function processDone() {

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -9,14 +9,12 @@ var Lines = module.exports = function Lines(opt) {
   if (!(this instanceof Lines)) return new Lines(opt);
   stream.Transform.call(this, {objectMode: true});
   this._buf = '';
-  this._newline = false;
 };
 util.inherits(Lines, stream.Transform);
 
 Lines.prototype._transform = function (chunk, encoding, done) {
-  var data = this._buf + chunk.toString('utf8');
-  var lines = data.split(/\r\n|\r|\n/);
-  this._newline = data[data.length - 1] === '\n';
+  var data = this._buf + chunk.toString();
+  var lines = data.split('\n');
   this._buf = lines.pop();
   done(null, lines);
 };
@@ -24,5 +22,4 @@ Lines.prototype._transform = function (chunk, encoding, done) {
 Lines.prototype._flush = function (done) {
   if (this._buf) this.push([this._buf]);
   done();
-  this.emit('endNewline', this._newline);
 };


### PR DESCRIPTION
Avoid a useless JSON.stringify() and JSON.parse() operations on each
entry in post-shuffle, by encoding keys and values on their own lines
and delaying parsing of key until pipeline iteration.

AggregateByKey and all derivates are now a few % faster.