### PR TITLE
save: support direct streaming to azure.

### DIFF
--- a/examples/save.js
+++ b/examples/save.js
@@ -2,8 +2,10 @@
 
 var sc = require('skale-engine').context();
 
-sc.range(900).save('/tmp/truc', {gzip: true}, (err, res) => {
+//sc.range(900).save('/tmp/truc', {gzip: true}, (err, res) => {
 // sc.range(900).save('s3://skale-demo/test/s1', {gzip: true}, (err, res) => {
+//sc.range(900).save('/tmp/truc', {stream: true}, (err, res) => {
+sc.range(900).save('/tmp/truc', {gzip: true, stream: true}, (err, res) => {
   console.log(res);
   sc.end();
 });

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -248,6 +248,7 @@ Dataset.prototype.save = thenify(function (path, options, done) {
   var opt = {
     gzip: options.gzip,
     parquet: options.parquet,
+    stream: options.stream,
     path: path,
     _preIterate: function (opt, wc, p) {
       var suffix = opt.gzip ? '.gz' : opt.parquet ? '.parquet' : '';
@@ -255,12 +256,32 @@ Dataset.prototype.save = thenify(function (path, options, done) {
       if (opt.parquet) {
         wc.parquetFile = new wc.lib.parquet.ParquetWriter(wc.exportFile, opt.parquet.schema, opt.parquet.compression);
       }
+      if (!opt.stream) return;
+      var url = wc.lib.url.parse(opt.path);
+      switch (url.protocol) {
+        case 'file:':
+        case null:
+          wc.log('save_preiterate, stream saving to', url.path + '/' + p + suffix);
+          wc.lib.mkdirp.sync(opt.path);
+          if (opt.gzip) {
+            var zlib = wc.lib.zlib, fs = wc.lib.fs;
+            wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
+            wc.outputStream.pipe(wc.lib.fs.createWriteStream(url.path + '/' + p + suffix));
+          } else
+            wc.outputStream = wc.lib.fs.createWriteStream(url.path + '/' + p + suffix);
+          break;
+        default:
+          wc.log('Error: unsupported protocol', url.protocol);
+      }
     },
     _postIterate: function (acc, opt, wc, p, done) {
       var suffix = opt.gzip ? '.gz' : opt.parquet ? '.parquet' : '';
       var fs = wc.lib.fs;
       var zlib = wc.lib.zlib;
       var url, readStream, writeStream;
+      if (opt.stream) {
+        return wc.outputStream.end(acc, done);
+      }
       if (opt.parquet) {
         wc.parquetFile.write(acc);
         wc.parquetFile.close();
@@ -319,6 +340,15 @@ Dataset.prototype.save = thenify(function (path, options, done) {
     }
   };
 
+  function streamReducer(acc, val, opt, wc) {
+    acc = acc.concat(JSON.stringify(val) + '\n');
+    if (acc.length >= 65536) {
+      wc.outputStream.write(str);
+      acc = '';
+    }
+    return acc;
+  }
+
   function reducer(acc, val, opt, wc) {
     acc = acc.concat(JSON.stringify(val) + '\n');
     if (acc.length >= 65536) {
@@ -349,6 +379,8 @@ Dataset.prototype.save = thenify(function (path, options, done) {
 
   if (opt.parquet)
     return this.aggregate(parquetReducer, function(){}, [], opt, done);
+  if (opt.stream)
+    return this.aggregate(streamReducer, function(){}, '', opt, done);
   return this.aggregate(reducer, function(){}, '', opt, done);
 });
 

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -201,7 +201,7 @@ Dataset.prototype.stream = function (options) {
   var pstreams = [];
 
   function reducer(acc, val, opt, wc) {
-    acc = acc.concat(JSON.stringify(val) + '\n');
+    acc += JSON.stringify(val) + '\n';
     if (acc.length >= 65536) {
       var fs = wc.lib.fs;
       if (opt.gzip) {
@@ -228,7 +228,7 @@ Dataset.prototype.stream = function (options) {
       outStream.add(pstreams[i]);
   });
 
-  if (options.end) outStream.on('end', self.sc.end);
+  if (options.end) outStream.once('end', self.sc.end);
   return outStream;
 };
 
@@ -260,15 +260,27 @@ Dataset.prototype.save = thenify(function (path, options, done) {
       var url = wc.lib.url.parse(opt.path);
       var zlib = wc.lib.zlib, fs = wc.lib.fs;
       switch (url.protocol) {
+      case 'wasb:':
+        var retry = new wc.lib.azure.ExponentialRetryPolicyFilter();
+        var az = wc.lib.azure.createBlobService().withFilter(retry);
+        wc.outputSystemStream = az.createWriteStreamToBlockBlob(url.auth, url.path.slice(1) + '/' + p + suffix);
+        if (opt.gzip) {
+          wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
+          wc.outputStream.pipe(wc.outputSystemStream);
+        } else
+          wc.outputStream = wc.outputSystemStream;
+        wc.log('save stream:', url.auth, url.path.slice(1) + '/' + p + suffix);
+        break;
       case 'file:':
       case null:
         wc.log('save_preiterate, stream saving to', url.path + '/' + p + suffix);
         wc.lib.mkdirp.sync(opt.path);
+        wc.outputSystemStream = fs.createWriteStream(url.path + '/' + p + suffix);
         if (opt.gzip) {
           wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
-          wc.outputStream.pipe(fs.createWriteStream(url.path + '/' + p + suffix));
+          wc.outputStream.pipe(wc.outputSystemStream);
         } else
-          wc.outputStream = fs.createWriteStream(url.path + '/' + p + suffix);
+          wc.outputStream = wc.outputSystemStream;
         break;
       default:
         wc.log('Error: unsupported protocol', url.protocol);
@@ -280,7 +292,8 @@ Dataset.prototype.save = thenify(function (path, options, done) {
       var zlib = wc.lib.zlib;
       var url, readStream, writeStream;
       if (opt.stream) {
-        return wc.outputStream.end(acc, done);
+        wc.outputSystemStream.once('close', done);
+        return wc.outputStream.end(acc);
       }
       if (opt.parquet) {
         wc.parquetFile.write(acc);
@@ -301,12 +314,8 @@ Dataset.prototype.save = thenify(function (path, options, done) {
         var az = wc.lib.azure.createBlobService().withFilter(retry);
         wc.log('upload', wc.exportFile, 'to', url.auth, url.path.slice(1) + '/' + p + suffix);
         az.createBlockBlobFromLocalFile(
-          url.auth,
-          url.path.slice(1) + '/' + p + suffix,
-          wc.exportFile, {
-            parallelOperationThreadCount: 1,
-            maximumExecutionTimeInMs: '3600000'
-          }, function (err) {
+          url.auth, url.path.slice(1) + '/' + p + suffix,
+          wc.exportFile, null, function (err) {
             if (err) wc.log('Azure upload error', err);
             done();
           }
@@ -331,7 +340,7 @@ Dataset.prototype.save = thenify(function (path, options, done) {
         wc.lib.mkdirp.sync(opt.path);
         writeStream = fs.createWriteStream(url.path + '/' + p + suffix);
         readStream.pipe(writeStream);
-        writeStream.on('close', done);
+        writeStream.once('close', done);
         break;
       default:
         wc.log('Error: unsupported protocol', url.protocol);
@@ -341,16 +350,16 @@ Dataset.prototype.save = thenify(function (path, options, done) {
   };
 
   function streamReducer(acc, val, opt, wc) {
-    acc = acc.concat(JSON.stringify(val) + '\n');
-    if (acc.length >= 65536) {
-      wc.outputStream.write(acc);
+    acc += JSON.stringify(val) + '\n';
+    if (acc.length > 99999) {
+      wc.outputStreamOk = wc.outputStream.write(acc);
       acc = '';
     }
     return acc;
   }
 
   function reducer(acc, val, opt, wc) {
-    acc = acc.concat(JSON.stringify(val) + '\n');
+    acc += JSON.stringify(val) + '\n';
     if (acc.length >= 65536) {
       var fs = wc.lib.fs;
       if (opt.gzip) {
@@ -610,7 +619,7 @@ function Stream(sc, stream, type) { // type = 'line' ou 'object'
 
   dataset.watched = true;         // notify skale to wait for file before launching
   dataset.parse = type === 'object';
-  out.on('close', function () {
+  out.once('close', function () {
     fs.renameSync(tmpFile, targetFile);
     dataset.watched = false;
   });
@@ -823,7 +832,7 @@ function iterateStream(readStream, task, pipeline, done) {
     }
   });
 
-  readStream.on('end', function () {
+  readStream.once('end', function () {
     if (tail) {
       var buffer = [tail];
       for (var t = 0; t < pipeline.length; t++)
@@ -908,7 +917,7 @@ function parquetStream(rs, name, task, pipeline, done) {
   task.log('Download ', filename);
   rs.pipe(ws);
 
-  ws.on('close', function () {
+  ws.once('close', function () {
     parquetIterate(filename, pipeline, done);
   });
 }
@@ -1282,7 +1291,7 @@ AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
           else cbuffer[k] = v;
         }
       });
-      stream.on('end', function () {
+      stream.once('end', function () {
         var v;
         if (lastk && tail.length) {
           v = JSON.parse(tail);
@@ -1298,12 +1307,32 @@ AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
     if (++cnt < files.length)
       return processShuffleFile(files[cnt], processDone);
 
-    for (var key in cbuffer) {
+    var i = 0, key;
+
+    var keys = Object.keys(cbuffer);
+    iterate();
+
+    function iterate() {
+      while (task.outputStreamOk) {
+        if (i === keys.length) return done();
+        key = keys[i++];
+        var buffer = [[JSON.parse(key), cbuffer[key]]];
+        for (var t = 0; t < pipeline.length; t++)
+          buffer = pipeline[t].transform(buffer);
+      }
+      task.outputStreamOk = true;
+      task.outputStream.once('drain', iterate);
+    }
+/*
+    //for (i = 0; i < keys.length; i++)
+    //  key = keys[i];
+    for (key in cbuffer) {
       var buffer = [[JSON.parse(key), cbuffer[key]]];
       for (var t = 0; t < pipeline.length; t++)
         buffer = pipeline[t].transform(buffer);
     }
     done();
+*/
   }
 };
 
@@ -1358,12 +1387,12 @@ Cartesian.prototype.iterate = function (task, p, pipeline, done) {
 
   task.getReadStream(this.shufflePartitions[p1].files, undefined, function (err, stream1) {
     stream1.on('data', function (s) {s1 += s;});
-    stream1.on('end', function () {
+    stream1.once('end', function () {
       var a1 = s1.split('\n');
       var s2 = '';
       task.getReadStream(self.shufflePartitions[p2].files, undefined, function (err, stream2) {
         stream2.on('data', function (s) {s2 += s;});
-        stream2.on('end', function () {
+        stream2.once('end', function () {
           var a2 = s2.split('\n');
           for (var i = 0; i < a1.length; i++) {
             if (a1[i] == '') continue;
@@ -1450,7 +1479,7 @@ SortBy.prototype.iterate = function (task, p, pipeline, done) {
       for (var i = 0; i < linev.length; i++)
         cbuffer.push(JSON.parse(linev[i]));
     });
-    lines.on('end', done);
+    lines.once('end', done);
   }
 
   function processDone() {
@@ -1538,7 +1567,7 @@ PartitionBy.prototype.iterate = function (task, p, pipeline, done) {
       for (var i = 0; i < linev.length; i++)
         cbuffer.push(JSON.parse(linev[i]));
     });
-    lines.on('end', done);
+    lines.once('end', done);
   }
 
   function processDone() {

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -258,20 +258,20 @@ Dataset.prototype.save = thenify(function (path, options, done) {
       }
       if (!opt.stream) return;
       var url = wc.lib.url.parse(opt.path);
+      var zlib = wc.lib.zlib, fs = wc.lib.fs;
       switch (url.protocol) {
-        case 'file:':
-        case null:
-          wc.log('save_preiterate, stream saving to', url.path + '/' + p + suffix);
-          wc.lib.mkdirp.sync(opt.path);
-          if (opt.gzip) {
-            var zlib = wc.lib.zlib, fs = wc.lib.fs;
-            wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
-            wc.outputStream.pipe(wc.lib.fs.createWriteStream(url.path + '/' + p + suffix));
-          } else
-            wc.outputStream = wc.lib.fs.createWriteStream(url.path + '/' + p + suffix);
-          break;
-        default:
-          wc.log('Error: unsupported protocol', url.protocol);
+      case 'file:':
+      case null:
+        wc.log('save_preiterate, stream saving to', url.path + '/' + p + suffix);
+        wc.lib.mkdirp.sync(opt.path);
+        if (opt.gzip) {
+          wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
+          wc.outputStream.pipe(fs.createWriteStream(url.path + '/' + p + suffix));
+        } else
+          wc.outputStream = fs.createWriteStream(url.path + '/' + p + suffix);
+        break;
+      default:
+        wc.log('Error: unsupported protocol', url.protocol);
       }
     },
     _postIterate: function (acc, opt, wc, p, done) {
@@ -343,7 +343,7 @@ Dataset.prototype.save = thenify(function (path, options, done) {
   function streamReducer(acc, val, opt, wc) {
     acc = acc.concat(JSON.stringify(val) + '\n');
     if (acc.length >= 65536) {
-      wc.outputStream.write(str);
+      wc.outputStream.write(acc);
       acc = '';
     }
     return acc;
@@ -501,7 +501,7 @@ function Partition(datasetId, partitionIndex, parentDatasetId, parentPartitionIn
   //this.skip = false;  // TODO: mv in worker only. true when partition is evicted due to memory shortage
 }
 
-Partition.prototype.transform = function (context, data) {
+Partition.prototype.transform = function (data) {
   if (this.skip) return data; // Passthrough if partition is evicted
 
   // Periodically check/update available memory, and evict partition
@@ -533,7 +533,7 @@ Partition.prototype.iterate = function (task, p, pipeline, done) {
   for (var i = 0; i < this.data.length; i++) {
     buffer = [this.data[i]];
     for (var t = 0; t < pipeline.length; t++)
-      buffer = pipeline[t].transform(pipeline[t], buffer);
+      buffer = pipeline[t].transform(buffer);
   }
   done();
 };
@@ -554,7 +554,7 @@ Source.prototype.iterate = function (task, p, pipeline, done) {
   for (i = 0; i < n; i++, index++) {
     buffer = [this.getItem(index, this.args, task)];
     for (var t = 0; t < pipeline.length; t++)
-      buffer = pipeline[t].transform(pipeline[t], buffer);
+      buffer = pipeline[t].transform(buffer);
   }
   done();
 };
@@ -633,7 +633,7 @@ function parquetIterate(path, pipeline, done) {
   for (i = 0; i < numRows; i++) {
     buffer = [rows[i]];
     for (t = 0; t < pipeline.length; t++)
-      buffer = pipeline[t].transform(pipeline[t], buffer);
+      buffer = pipeline[t].transform(buffer);
   }
   done();
   reader.close();
@@ -819,7 +819,7 @@ function iterateStream(readStream, task, pipeline, done) {
     for (var i = 0; i < lines.length; i++) {
       buffer = [lines[i]];
       for (var t = 0; t < pipeline.length; t++)
-        buffer = pipeline[t].transform(pipeline[t], buffer);
+        buffer = pipeline[t].transform(buffer);
     }
   });
 
@@ -827,7 +827,7 @@ function iterateStream(readStream, task, pipeline, done) {
     if (tail) {
       var buffer = [tail];
       for (var t = 0; t < pipeline.length; t++)
-        buffer = pipeline[t].transform(pipeline[t], buffer);
+        buffer = pipeline[t].transform(buffer);
     }
     done();
   });
@@ -1001,14 +1001,14 @@ TextFile.prototype.iterate = function (task, p, pipeline, done) {
     if (!line) return;  // skip empty lines
     buffer = [line];
     for (var t = 0; t < pipeline.length; t++)
-      buffer = pipeline[t].transform(pipeline[t], buffer);
+      buffer = pipeline[t].transform(buffer);
   }
 
   function processLineParse(line) {
     if (!line) return;  // skip empty lines
     buffer = [JSON.parse(line)];
     for (var t = 0; t < pipeline.length; t++)
-      buffer = pipeline[t].transform(pipeline[t], buffer);
+      buffer = pipeline[t].transform(buffer);
   }
 
   task.lib.readSplit(this.splits, this.splits[p].index, this.parse ? processLineParse : processLine, done, function (part, opt) {
@@ -1027,7 +1027,7 @@ function Map(parent, mapper, args) {
 
 inherits(Map, Dataset);
 
-Map.prototype.transform = function map(context, data) {
+Map.prototype.transform = function map(data) {
   var tmp = [];
   for (var i = 0; i < data.length; i++)
     tmp[i] = this.mapper(data[i], this.args, this.global);
@@ -1043,7 +1043,7 @@ function FlatMap(parent, mapper, args) {
 
 inherits(FlatMap, Dataset);
 
-FlatMap.prototype.transform = function flatmap(context, data) {
+FlatMap.prototype.transform = function flatmap(data) {
   var tmp = [];
   for (var i = 0; i < data.length; i++)
     tmp = tmp.concat(this.mapper(data[i], this.args, this.global));
@@ -1059,7 +1059,7 @@ function MapValues(parent, mapper, args) {
 
 inherits(MapValues, Dataset);
 
-MapValues.prototype.transform = function (context, data) {
+MapValues.prototype.transform = function (data) {
   var tmp = [];
   for (var i = 0; i < data.length; i++)
     tmp[i] = [data[i][0], this.mapper(data[i][1], this.args, this.global)];
@@ -1075,7 +1075,7 @@ function FlatMapValues(parent, mapper, args) {
 
 inherits(FlatMapValues, Dataset);
 
-FlatMapValues.prototype.transform = function (context, data) {
+FlatMapValues.prototype.transform = function (data) {
   var tmp = [];
   for (var i = 0; i < data.length; i++) {
     var t0 = this.mapper(data[i][1], this.args, this.global);
@@ -1093,7 +1093,7 @@ function Filter(parent, filter, args) {
 
 inherits(Filter, Dataset);
 
-Filter.prototype.transform = function (context, data) {
+Filter.prototype.transform = function (data) {
   var tmp = [];
   for (var i = 0; i < data.length; i++)
     if (this._filter(data[i], this.args, this.global)) tmp.push(data[i]);
@@ -1145,7 +1145,7 @@ function Sample(parent, withReplacement, frac, seed) {
 
 inherits(Sample, Dataset);
 
-Sample.prototype.transform = function (context, data) {
+Sample.prototype.transform = function (data) {
   var tmp = [], i, j;
   if (this.withReplacement) {
     for (i = 0; i < data.length; i++)
@@ -1164,7 +1164,7 @@ function Union(sc, parents) {
 
 inherits(Union, Dataset);
 
-Union.prototype.transform = function (context, data) {return data;};
+Union.prototype.transform = function (data) {return data;};
 
 function AggregateByKey(sc, dependencies, reducer, combiner, init, args) {
   Dataset.call(this, sc, dependencies);
@@ -1193,7 +1193,7 @@ AggregateByKey.prototype.getPartitions = function (done) {
   done();
 };
 
-AggregateByKey.prototype.transform = function (context, data) {
+AggregateByKey.prototype.transform = function (data) {
   var i, d, key, buf = this.buffer, acc;
   for (i = 0; i < data.length; i++) {
     d = data[i];
@@ -1301,7 +1301,7 @@ AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
     for (var key in cbuffer) {
       var buffer = [[JSON.parse(key), cbuffer[key]]];
       for (var t = 0; t < pipeline.length; t++)
-        buffer = pipeline[t].transform(pipeline[t], buffer);
+        buffer = pipeline[t].transform(buffer);
     }
     done();
   }
@@ -1330,7 +1330,7 @@ Cartesian.prototype.getPartitions = function (done) {
   done();
 };
 
-Cartesian.prototype.transform = function (context, data) {
+Cartesian.prototype.transform = function (data) {
   for (var i = 0; i < data.length; i++) this.buffer.push(data[i]);
 };
 
@@ -1371,7 +1371,7 @@ Cartesian.prototype.iterate = function (task, p, pipeline, done) {
               if (a2[j] == '') continue;
               var buffer = [[JSON.parse(a1[i]), JSON.parse(a2[j])]];
               for (var t = 0; t < pipeline.length; t++)
-                buffer = pipeline[t].transform(pipeline[t], buffer);
+                buffer = pipeline[t].transform(buffer);
             }
           }
           done();
@@ -1406,7 +1406,7 @@ SortBy.prototype.getPartitions = function (done) {
   } else done();
 };
 
-SortBy.prototype.transform = function (context, data) {
+SortBy.prototype.transform = function (data) {
   for (var i = 0; i < data.length; i++) {
     var pid = this.partitioner.getPartitionIndex(this.keyFunc(data[i]));
     if (this.buffer[pid] === undefined) this.buffer[pid] = [];
@@ -1459,7 +1459,7 @@ SortBy.prototype.iterate = function (task, p, pipeline, done) {
       for (var i = 0; i < cbuffer.length; i++) {
         var buffer = [cbuffer[i]];
         for (var t = 0; t < pipeline.length; t++)
-          buffer = pipeline[t].transform(pipeline[t], buffer);
+          buffer = pipeline[t].transform(buffer);
       }
       done();
     } else processShuffleFile(files[cnt], processDone);
@@ -1494,7 +1494,7 @@ PartitionBy.prototype.getPartitions = function (done) {
   } else done();
 };
 
-PartitionBy.prototype.transform = function (context, data) {
+PartitionBy.prototype.transform = function (data) {
   for (var i = 0; i < data.length; i++) {
     var pid = this.partitioner.getPartitionIndex(data[i][0]);
     if (this.buffer[pid] === undefined) this.buffer[pid] = [];
@@ -1546,7 +1546,7 @@ PartitionBy.prototype.iterate = function (task, p, pipeline, done) {
       for (var i = 0; i < cbuffer.length; i++) {
         var buffer = [cbuffer[i]];
         for (var t = 0; t < pipeline.length; t++)
-          buffer = pipeline[t].transform(pipeline[t], buffer);
+          buffer = pipeline[t].transform(buffer);
       }
       done();
     } else processShuffleFile(files[cnt], processDone);

--- a/lib/task.js
+++ b/lib/task.js
@@ -41,11 +41,11 @@ Task.prototype.run = function(done) {
 
   if (action) {
     if (action.opt._foreach) {
-      pipeline.push({transform: function foreach(context, data) {
+      pipeline.push({transform: function foreach(data) {
         for (var i = 0; i < data.length; i++) action.src(data[i], action.opt, self);
       }});
     } else {
-      pipeline.push({transform: function aggregate(context, data) {
+      pipeline.push({transform: function aggregate(data) {
         for (var i = 0; i < data.length; i++)
           action.init = action.src(action.init, data[i], action.opt, self);
       }});

--- a/lib/task.js
+++ b/lib/task.js
@@ -13,6 +13,7 @@ function Task(init) {
   this.pid = init.pid;
   this.nodes = init.nodes;
   this.action = init.action;
+  this.outputStreamOk = true;
   this.files = {};      // object in which we store shuffle file informations to be sent back to master
 //  this.lib;         // handler to libraries required on worker side (which cannot be serialized)
 //  this.mm;          // handler to worker side memory manager instance 


### PR DESCRIPTION
Streaming at save avoids to write on local disk prior to upload data to final destination, and accelerates result stage.

Stream back-pressure is handled in AggregateByKey post-shuffle iteration loop. This strategy must be applied to other iteration loops, allowing to stream also pre-shuffle, and to interpose on-the-fly asynchronous compression efficiently.

Once it is done, stream at save will be the default option.