### PR TITLE
Fix a worker crash when using ds.sample() with replacement.

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -146,6 +146,8 @@ function runWorker(host, port) {
   } else {
     log = function () {};
   }
+  if (process.env.SKALE_RANDOM_SEED)
+    Dataset.setRandomSeed(process.SKALE_RANDOM_SEED);
   process.title = 'skale-worker_' + wid;
   process.on('uncaughtException', function (err) {
     grid.send(grid.muuid, {cmd: 'workerError', args: err.stack});

--- a/examples/sample.js
+++ b/examples/sample.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
+process.env.SKALE_RANDOM_SEED = 'skale';
+
 var sc = require('skale-engine').context();
 
 sc.parallelize([1, 2, 3, 4])
   .sample(false, 0.8)
   .collect(function(err, res) {
     console.log(res);
-    console.assert(JSON.stringify(res) === JSON.stringify([1, 2, 3, 4])); 
+    console.assert(JSON.stringify(res) === JSON.stringify([1, 2, 4]));
     sc.end();
   });

--- a/index.js
+++ b/index.js
@@ -17,6 +17,5 @@ module.exports = {
   context: Context,
   HashPartitioner: Dataset.HashPartitioner,
   RangePartitioner: Dataset.RangePartitioner,
-  Random: Dataset.Random,
   Source: Dataset.Source
 };

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -11,6 +11,7 @@ var uuid = require('uuid');
 var merge2 = require('merge2');
 var glob = require('glob');
 var micromatch = require('micromatch');
+var seedrandom = require('seedrandom');
 var aws = require('aws-sdk');
 var azure = require('azure-storage');
 
@@ -1114,32 +1115,30 @@ function Random(seed) {
     return this.y = (u ^ (u >> 22)) ^ (t ^ (t >> 9));
   };
 
-  // Return a float in range [0, 1) like Math.Random()
+  // Return a float in range [0, 1) like Math.random()
   this.nextDouble = function () {
     return this.next() / 4294967296.0;
   };
 }
 
-function Poisson(lambda, initSeed) {
-  initSeed = initSeed || 1;
-
-  var rng = new Random(initSeed);
+function Poisson(lambda) {
+  this.L = Math.exp(-lambda);
 
   this.sample = function () {
-    var L = Math.exp(-lambda), k = 0, p = 1;
+    var k = 0, p = 1;
     do {
       k++;
-      p *= rng.nextDouble();
-    } while (p > L);
+      p *= Math.random();
+    } while (p > this.L);
     return k - 1;
   };
 }
 
-function Sample(parent, withReplacement, frac, seed) {
+function Sample(parent, withReplacement, frac) {
   Dataset.call(this, parent.sc, [parent]);
   this.withReplacement = withReplacement;
   this.frac = frac;
-  this.rng = withReplacement ? new Poisson(frac, seed) : new Random(seed);
+  this.rng = new Poisson(frac);
   this.type = 'Sample';
 }
 
@@ -1152,7 +1151,7 @@ Sample.prototype.transform = function (data) {
       for (j = 0; j < this.rng.sample(); j++) tmp.push(data[i]);
   } else {
     for (i = 0; i < data.length; i++)
-      if (this.rng.nextDouble() < this.frac) tmp[i] = data[i];
+      if (Math.random() < this.frac) tmp[i] = data[i];
   }
   return tmp;
 };
@@ -1634,11 +1633,16 @@ function deepCopy(o) {
   return n;
 }
 
+function setRandomSeed(seed) {
+  seedrandom(seed, {global: true});
+}
+
 module.exports = {
   Dataset: Dataset,
   Partition: Partition,
   parallelize: parallelize,
   range: range,
+  setRandomSeed: setRandomSeed,
   TextLocal: TextLocal,
   TextS3: TextS3,
   TextAzure: TextAzure,

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -1101,26 +1101,6 @@ Filter.prototype.transform = function (data) {
   return tmp;
 };
 
-function Random(seed) {
-  seed = seed || 0;
-  this.x = 123456789 + seed;
-  this.y = 188675123;
-
-  // xorshift RNG producing a sequence of 2 ** 64 - 1 32 bits integers
-  // See http://www.jstatsoft.org/v08/i14/paper by G. Marsaglia
-  this.next = function () {
-    var t = this.x, u = this.y;
-    t ^= t << 8;
-    this.x = u;
-    return this.y = (u ^ (u >> 22)) ^ (t ^ (t >> 9));
-  };
-
-  // Return a float in range [0, 1) like Math.random()
-  this.nextDouble = function () {
-    return this.next() / 4294967296.0;
-  };
-}
-
 function Poisson(lambda) {
   this.L = Math.exp(-lambda);
 
@@ -1648,7 +1628,6 @@ module.exports = {
   TextAzure: TextAzure,
   Source: Source,
   Stream: Stream,
-  Random: Random,
   Map: Map,
   FlatMap: FlatMap,
   MapValues: MapValues,

--- a/lib/worker-local.js
+++ b/lib/worker-local.js
@@ -28,6 +28,9 @@ var mm = new MemoryManager(memory);
 
 var start = process.hrtime();
 
+if (process.env.SKALE_RANDOM_SEED)
+  Dataset.setRandomSeed(process.env.SKALE_RANDOM_SEED);
+
 process.title = 'skale-worker-' + workerId;
 
 process.on('disconnect', function () {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mkdirp": "^0.5.1",
     "node-getopt": "^0.2.3",
     "rimraf": "^2.5.4",
+    "seedrandom": "^2.4.3",
     "thenify": "^3.2.1",
     "uuid": "^3.0.1",
     "websocket-stream": "^3.3.3",

--- a/test/engine-test.js
+++ b/test/engine-test.js
@@ -1,5 +1,7 @@
 // Copyright 2016 Luca-SAS, licensed under the Apache License 2.0
 
+process.env.SKALE_RANDOM_SEED = 'skale';
+
 var fs = require('fs');
 var net = require('net');
 var spawn = require('child_process').spawn;
@@ -61,7 +63,7 @@ var transforms = [
   {name: 'mapValues', args: [data.valueMapper]},
 //  {name: 'persist', args: []},
   {name: 'reduceByKey', args: [function (a, b) {return a + b;}, 0], sort: true}
-//  {name: 'sample', args: [true, 0.1], sort: true, lengthOnly: true},
+//  {name: 'sample', args: [false, 0.9], sort: true, lengthOnly: true}
 //  {name: 'values', args: []},
 ];
 

--- a/test/support/local-array.js
+++ b/test/support/local-array.js
@@ -7,8 +7,13 @@ var stream = require('stream');
 var os = require('os');
 var util = require('util');
 var thenify = require('thenify').withCallback;
+var seedrandom = require('seedrandom');
 //var trace = require('line-trace');
 var Lines = require('../../lib/lines.js');
+
+
+if (process.env.SKALE_RANDOM_SEED)
+  seedrandom(process.env.SKALE_RANDOM_SEED, {global: true});
 
 module.exports = LocalArray;
 module.exports.TextStream = TextStream;
@@ -522,16 +527,13 @@ function sample(v, withReplacement, frac, num, seed) {
   for (var w = 0; w < P; w++) {
     var p = 0;
     var tmp = [];
-    // FIXME: include a random class
-    //var rng = new ml.Random(seed);
-    var rng;
     for (i in workerMap[w]) {
       var L = workerMap[w][i].length;
       L = num ? num : Math.ceil(L * frac);
       tmp[p] = {data: []};
       var idxVect = [];
       while (tmp[p].data.length != L) {
-        var idx = Math.round(Math.abs(rng.next()) * (L - 1));
+        var idx = Math.round(Math.abs(Math.random()) * (L - 1));
         if ((idxVect.indexOf(idx) != -1) &&  !withReplacement)
           continue; // if already picked but no replacement mode
         idxVect.push[idx];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,6 +1338,10 @@ sax@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.5.tgz#1da50a8d00cdecd59405659f5ff85349fe773743"
 
+seedrandom@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
+
 shelljs@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8"


### PR DESCRIPTION
Also use again Math.random(), and allow to set a random seed using
the external seedrandom module. Use env SKALE_RANDOM_SEED to
set a seed. Setting a seed induce a performance penalty, as it
uses a pure JS random function instead of the native one.