### PR TITLE
textFile: Fix handling of gzipped files in local filesystem

### DIFF
--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -695,10 +695,8 @@ TextS3File.prototype.iterate = function (task, p, pipeline, done) {
   task.log('stream s3', this.bucket, this.path);
   if (this.options.parquet || this.path.slice(-8) === '.parquet')
     return parquetStream(rs, this.path, task, pipeline, done);
-
   if (this.path.slice(-3) === '.gz')
     rs = rs.pipe(task.lib.zlib.createGunzip({chunkSize: 65536}));
-
   iterateStream(rs, task, pipeline, done);
 };
 
@@ -948,7 +946,8 @@ TextLocal.prototype.iterate = function (task, p, pipeline, done) {
     return parquetIterate(path, pipeline, done);
   var rs = task.lib.fs.createReadStream(path);
   if (path.slice(-3) === '.gz')
-    rs.pipe(task.lib.zlib.createGunzip({chunkSize: 65536}));
+    rs = rs.pipe(task.lib.zlib.createGunzip({chunkSize: 65536}));
+
   iterateStream(rs, task, pipeline, done);
 };
 


### PR DESCRIPTION
The returned stream was operating on the compressed data instead ofs
uncompressed.