### PR TITLE
performance: block processing for pipelines at source level, part 2

### DIFF
--- a/lib/context-local.js
+++ b/lib/context-local.js
@@ -87,6 +87,8 @@ function Context(arg) {
 
   this.runTask = function (task, callback) {
     task._start = process.hrtime();
+    task.blockSize = this.blockSize;
+
     function getLeastBusyWorkerId(/* preferredLocation */) {
       var wid, ntask;
       for (var i = 0; i < self.worker.length; i++) {
@@ -155,7 +157,6 @@ function Context(arg) {
     if (!this.worker[wid].init) {
       this.worker[wid].init = true;
       task.env = this.env;
-      task.blockSize = this.blockSize;
     }
 
     var str = serialize(task);

--- a/lib/context.js
+++ b/lib/context.js
@@ -131,6 +131,7 @@ function SkaleContext(arg) {
 
   this.runTask = function(task, callback) {
     task._start = process.hrtime();
+    task.blockSize = this.blockSize;
 
     function getLeastBusyWorkerId(/* preferredLocation */) {
       var wid, ntask;
@@ -201,7 +202,6 @@ function SkaleContext(arg) {
     if (!this.worker[wid].init) {
       this.worker[wid].init = true;
       task.env = this.env;
-      task.blockSize = this.blockSize;
     }
 
     this.worker[wid].ntask++;

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -561,13 +561,10 @@ Partition.prototype.transform = function (data) {
 };
 
 Partition.prototype.iterate = function (task, p, pipeline, done) {
-  var buffer;
+  var buffer = this.data, t;
 
-  for (var i = 0; i < this.data.length; i++) {
-    buffer = [this.data[i]];
-    for (var t = 0; t < pipeline.length; t++)
-      buffer = pipeline[t].transform(buffer);
-  }
+  for (t = 0; t < pipeline.length; t++)
+    buffer = pipeline[t].transform(buffer);
   done();
 };
 
@@ -582,11 +579,18 @@ function Source(sc, N, getItem, args, npart) {
 inherits(Source, Dataset);
 
 Source.prototype.iterate = function (task, p, pipeline, done) {
-  var buffer, i, index = this.bases[p], n = this.sizes[p];
+  var buffer = [], index = this.bases[p], n = this.sizes[p], i, t;
 
   for (i = 0; i < n; i++, index++) {
-    buffer = [this.getItem(index, this.args, task)];
-    for (var t = 0; t < pipeline.length; t++)
+    buffer.push(this.getItem(index, this.args, task));
+    if (buffer.length == task.blockSize) {
+      for (t = 0; t < pipeline.length; t++)
+        buffer = pipeline[t].transform(buffer);
+      buffer = [];
+    }
+  }
+  if (buffer.length) {
+    for (t = 0; t < pipeline.length; t++)
       buffer = pipeline[t].transform(buffer);
   }
   done();
@@ -654,17 +658,24 @@ function Stream(sc, stream, type) { // type = 'line' ou 'object'
   return dataset;
 }
 
-function parquetIterate(path, pipeline, done) {
+function parquetIterate(path, task, pipeline, done) {
   var reader = new parquet.ParquetReader(path);
   var info = reader.info();
   var numRows = info.rows;
   var rows = reader.rows(numRows);
   var i, t;
-  var buffer;
+  var buffer = [];
 
 //  task.log('rows:', rows);
   for (i = 0; i < numRows; i++) {
-    buffer = [rows[i]];
+    buffer.push(rows[i]);
+    if (buffer.length == task.blockSize) {
+      for (t = 0; t < pipeline.length; t++)
+        buffer = pipeline[t].transform(buffer);
+      buffer = [];
+    }
+  }
+  if (buffer.length) {
     for (t = 0; t < pipeline.length; t++)
       buffer = pipeline[t].transform(buffer);
   }
@@ -794,8 +805,8 @@ function iterateStream(readStream, task, pipeline, done) {
 
   readStream.once('end', function () {
     if (tail) {
-      var buffer = [tail];
-      for (var t = 0; t < pipeline.length; t++)
+      var buffer = [tail], t;
+      for (t = 0; t < pipeline.length; t++)
         buffer = pipeline[t].transform(buffer);
     }
     done();
@@ -883,7 +894,7 @@ function parquetStream(rs, name, task, pipeline, done) {
   rs.pipe(ws);
 
   ws.once('close', function () {
-    parquetIterate(filename, pipeline, done);
+    parquetIterate(filename, task, pipeline, done);
   });
 }
 
@@ -923,7 +934,7 @@ TextLocal.prototype.iterate = function (task, p, pipeline, done) {
   var path = this.partitions[p].path, rs;
   task.log('stream local', path);
   if (this.options.parquet || path.slice(-8) === '.parquet')
-    return parquetIterate(path, pipeline, done);
+    return parquetIterate(path, task, pipeline, done);
   rs = task.lib.fs.createReadStream(path);
   if (path.slice(-3) === '.gz')
     rs = rs.pipe(zlib.createGunzip({chunkSize: 65536}));
@@ -1285,16 +1296,6 @@ AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
       task.outputStreamOk = true;
       task.outputStream.once('drain', iterate);
     }
-/*
-    //for (i = 0; i < keys.length; i++)
-    //  key = keys[i];
-    for (key in cbuffer) {
-      var buffer = [[JSON.parse(key), cbuffer[key]]];
-      for (var t = 0; t < pipeline.length; t++)
-        buffer = pipeline[t].transform(buffer);
-    }
-    done();
-*/
   }
 };
 

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -31,7 +31,7 @@ function Dataset(sc, dependencies) {
 
 Dataset.prototype.persist = function () {this.persistent = true; return this;};
 
-Dataset.prototype.map = function (mapper, args) {return new Map(this, mapper, args);};
+Dataset.prototype.map = function (mapper, args) {return new _Map(this, mapper, args);};
 
 Dataset.prototype.flatMap = function (mapper, args) {return new FlatMap(this, mapper, args);};
 
@@ -789,20 +789,6 @@ function iterateStream(readStream, task, pipeline, done) {
       lines = pipeline[t].transform(lines);
   });
 
-/*
-  readStream.on('data', function (chunk) {
-    var str = tail + chunk, start = 0, end, buffer;
-
-    while ((end = str.indexOf('\n', start)) !== -1) {
-      buffer = [str.substr(start, end - start)];
-      for (var t = 0; t < pipeline.length; t++)
-        buffer = pipeline[t].transform(buffer);
-      start = end + 1;
-    }
-    tail = str.substr(start, str.length - start);
-  });
-*/
-
   readStream.once('end', function () {
     if (tail) {
       var buffer = [tail], t;
@@ -1009,16 +995,16 @@ TextLocal.prototype.iterate = function (task, p, pipeline, done) {
 //
 //TextFile.prototype.getPreferedLocation = function (pid) {return this.splits[pid].ip;};
 
-function Map(parent, mapper, args) {
+function _Map(parent, mapper, args) {
   Dataset.call(this, parent.sc, [parent]);
   this.mapper = mapper;
   this.args = args;
   this.type = 'Map';
 }
 
-inherits(Map, Dataset);
+inherits(_Map, Dataset);
 
-Map.prototype.transform = function map(data) {
+_Map.prototype.transform = function map(data) {
   var tmp = [];
   for (var i = 0; i < data.length; i++)
     tmp[i] = this.mapper(data[i], this.args, this.global);
@@ -1170,16 +1156,12 @@ AggregateByKey.prototype.getPartitions = function (done) {
 };
 
 AggregateByKey.prototype.transform = function (data) {
-  //var i, d, key, buf = this.buffer, acc;
-  var i, key, acc;
+  var i, d, key, acc, buf = this.buffer;
   for (i = 0; i < data.length; i++) {
-    //d = data[i];
-    //key = JSON.stringify(d[0]);
-    //acc = (key in buf) ? buf[key] : deepCopy(this.init);
-    //buf[key] = this.reducer(acc, d[1], this.args, this.global);
-    key = JSON.stringify(data[i][0]);
-    acc = (key in this.buffer) ? this.buffer[key] : deepCopy(this.init);
-    this.buffer[key] = this.reducer(acc, data[i][1], this.args, this.global);
+    d = data[i];
+    key = JSON.stringify(d[0]);
+    acc = (key in buf) ? buf[key] : deepCopy(this.init);
+    buf[key] = this.reducer(acc, d[1], this.args, this.global);
   }
 };
 
@@ -1233,7 +1215,7 @@ AggregateByKey.prototype.spillToDisk = function (task, done) {
 };
 
 AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
-  var self = this, i, cbuffer = {}, cnt = 0, file, files = [], shuffleFiles = {};
+  var self = this, cnt = 0, file, files = [], shuffleFiles = {}, map = new Map(), i;
 
   for (i = 0; i < self.nShufflePartitions; i++) {
     file = self.shufflePartitions[i].files[p];
@@ -1252,23 +1234,25 @@ AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
 
       // Input format: interleaving of key lines and value lines
       stream.on('data', function (buf) {
-        var data = tail + buf.toString(), lines = data.split('\n'), len, i = 0, k, v;
+        var data = tail + buf.toString(), lines = data.split('\n'), len, i = 0, k, v, m;
         tail = lines.pop();
         len = lastk ? lines.unshift(lastk) : lines.length;
         lastk = (len & 1) ? lines.pop() : undefined;
         while (i < lines.length) {
           k = lines[i++];
           v = JSON.parse(lines[i++]);
-          if (k in cbuffer) cbuffer[k] = self.combiner(cbuffer[k], v, self.args, self.global);
-          else cbuffer[k] = v;
+          m = map.get(k);
+          if (m !== undefined) map.set(k, self.combiner(map.get(k), v, self.args, self.global));
+          else map.set(k, v);
         }
       });
       stream.once('end', function () {
-        var v;
+        var m, v;
         if (lastk && tail.length) {
           v = JSON.parse(tail);
-          if (lastk in cbuffer) cbuffer[lastk] = self.combiner(cbuffer[lastk], v, self.args, self.global);
-          else cbuffer[lastk] = v;
+          m = map.get(lastk);
+          if (m !== undefined) map.set(lastk, self.combiner(m, v, self.args, self.global));
+          else map.set(lastk, v);
         }
         task.dlog(start, 'processed', file.path, file.size);
         done();
@@ -1280,18 +1264,26 @@ AggregateByKey.prototype.iterate = function (task, p, pipeline, done) {
     if (++cnt < files.length)
       return processShuffleFile(files[cnt], processDone);
 
-    var i = 0, key;
-
-    var keys = Object.keys(cbuffer);
+    var it = map.entries(), buffer = [];
     iterate();
 
     function iterate() {
+      var t, kv;
       while (task.outputStreamOk) {
-        if (i === keys.length) return done();
-        key = keys[i++];
-        var buffer = [[JSON.parse(key), cbuffer[key]]];
-        for (var t = 0; t < pipeline.length; t++)
-          buffer = pipeline[t].transform(buffer);
+        kv = it.next().value;
+        if (!kv) {
+          if (buffer.length) {
+            for (t = 0; t < pipeline.length; t++)
+              buffer = pipeline[t].transform(buffer);
+          }
+          return done();
+        }
+        buffer.push([JSON.parse(kv[0]), kv[1]]);
+        if (buffer.length == task.blockSize) {
+          for (t = 0; t < pipeline.length; t++)
+            buffer = pipeline[t].transform(buffer);
+          buffer = [];
+        }
       }
       task.outputStreamOk = true;
       task.outputStream.once('drain', iterate);
@@ -1621,7 +1613,7 @@ module.exports = {
   TextAzure: TextAzure,
   Source: Source,
   Stream: Stream,
-  Map: Map,
+  Map: _Map,
   FlatMap: FlatMap,
   MapValues: MapValues,
   FlatMapValues: FlatMapValues,


### PR DESCRIPTION
Using block processing allows to eliminate most of the transforms
function call overhead in the stage pipeline processing, as it is
propagated and amplified through all stage transforms.

Maintaining a small block size improves data locality in the
L1/L2 caches during successive pipeline transforms, therefore
the default block size is 128, settable by SKALE_BLOCK_SIZE or
blockSize option at context creation.