### PR TITLE
aggregateByKey: fix a bug where undefined key crashes post-shuffle

### DIFF
--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -1181,6 +1181,7 @@ AggregateByKey.prototype.transform = function (data) {
   var i, d, key, acc, buf = this.buffer;
   for (i = 0; i < data.length; i++) {
     d = data[i];
+    if (d[0] === undefined) continue;
     key = JSON.stringify(d[0]);
     acc = (key in buf) ? buf[key] : deepCopy(this.init);
     buf[key] = this.reducer(acc, d[1], this.args, this.global);


### PR DESCRIPTION
Undefined key may occur during a join where key is absent in the other dataset.
Undefined value can not be JSON stringified then JSON parsed thus the crash.
Solution is simply to skip entries with undefined keys.