### PR TITLE
Convert DataSet Object and related functions to modern JS

### DIFF
--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -57,14 +57,14 @@ Dataset.prototype.reduceByKey = function (reducer, init, args) {
 
 Dataset.prototype.groupByKey = function () {
   const reducer = (a, b) => {a.push(b); return a;};
-  const combiner = (a, b) => {return a.concat(b);};
+  const combiner = (a, b) => a.concat(b);
   return new AggregateByKey(this.sc, [this], reducer, combiner, [], {});
 };
 
 Dataset.prototype.coGroup = function (other) {
   const reducer = (a, b) => {a.push(b); return a;};
   const combiner = (a, b) => {
-    for (var i = 0; i < b.length; i++) a[i] = a[i].concat(b[i]);
+    for (let i = 0; i < b.length; i++) a[i] = a[i].concat(b[i]);
     return a;
   };
   return new AggregateByKey(this.sc, [this, other], reducer, combiner, [], {});
@@ -87,10 +87,9 @@ Dataset.prototype.sortByKey = function (ascending, numPartitions) {
 Dataset.prototype.join = function (other) {
   return this.coGroup(other).flatMapValues(v => {
     const res = [];
-    let i, j;
 
-    for (i in v[0])
-      for (j in v[1])
+    for (let i in v[0])
+      for (let j in v[1])
         res.push([v[0][i], v[1][j]]);
     return res;
   });
@@ -99,13 +98,12 @@ Dataset.prototype.join = function (other) {
 Dataset.prototype.leftOuterJoin = function (other) {
   return this.coGroup(other).flatMapValues(v => {
     const res = [];
-    let i, j;
 
     if (v[1].length === 0) {
-      for (i in v[0]) res.push([v[0][i], null]);
+      for (let i in v[0]) res.push([v[0][i], null]);
     } else {
-      for (i in v[0])
-        for (j in v[1]) res.push([v[0][i], v[1][j]]);
+      for (let i in v[0])
+        for (let j in v[1]) res.push([v[0][i], v[1][j]]);
     }
     return res;
   });
@@ -114,13 +112,12 @@ Dataset.prototype.leftOuterJoin = function (other) {
 Dataset.prototype.rightOuterJoin = function (other) {
   return this.coGroup(other).flatMapValues(v => {
     const res = [];
-    let i, j;
 
     if (v[0].length === 0) {
-      for (i in v[1]) res.push([null, v[1][i]]);
+      for (let i in v[1]) res.push([null, v[1][i]]);
     } else {
-      for (i in v[0])
-        for (j in v[1]) res.push([v[0][i], v[1][j]]);
+      for (let i in v[0])
+        for (let j in v[1]) res.push([v[0][i], v[1][j]]);
     }
     return res;
   });
@@ -150,7 +147,7 @@ Dataset.prototype.subtract = function (other) {
   return a.coGroup(b).flatMap(a => {
     const res = [];
     if (a[1][0].length && (a[1][1].length === 0))
-      for (var i = 0; i < a[1][0][0]; i++) res.push(a[0]);
+      for (let i = 0; i < a[1][0][0]; i++) res.push(a[0]);
     return res;
   });
 };
@@ -226,12 +223,13 @@ Dataset.prototype.stream = function (options = {}) {
   };
 
   const combiner = (acc1, acc2) => {
-    var p = acc2.path.match(/.+\/([0-9]+)/)[1];
+    const p = acc2.path.match(/.+\/([0-9]+)/)[1];
     pstreams[p] = self.sc.getReadStreamSync(acc2);
   };
 
   this.aggregate(reducer, combiner, '', opt, () => {
-    pstreams.forEach(pstream => outStream.add(pstream));
+    for (var i = 0; i < pstreams.length; i++)
+      outStream.add(pstreams[i]);
   });
 
   if (options.end) outStream.once('end', self.sc.end);
@@ -257,13 +255,11 @@ Dataset.prototype.save = thenify(function (path, options = {}, done) {
     csv: options.csv,
     path: path,
     _preIterate: function (opt, wc, p) {
-      let suffix = '';
+      let suffix = opt.gzip ? '.gz' : opt.parquet ? '.parquet' : '';
 
-      if (opt.gzip) suffix = '.gz';
-      if (opt.parquet) suffix = '.parquet';
-      if (opt.csv) suffix = `.csv${suffix}`;
+      if (opt.csv) suffix = '.csv' + suffix;
 
-      wc.exportFile = `${wc.basedir}export/${p}${suffix}`;
+      wc.exportFile = wc.basedir + 'export/' + p + suffix;
 
       if (opt.parquet) {
         wc.parquetFile = new wc.lib.parquet.ParquetWriter(wc.exportFile, opt.parquet.schema, opt.parquet.compression);
@@ -283,7 +279,7 @@ Dataset.prototype.save = thenify(function (path, options = {}, done) {
         }
         wc.uploadPromise = s3.upload({
           Bucket: url.host,
-          Key: `${url.path.slice(1)}/${p}${suffix}`,
+          Key: url.path.slice(1) + '/' + p + suffix,
           Body: wc.outputStream
         }, err => {
           if (err) wc.log('S3 upload error', err);
@@ -294,22 +290,22 @@ Dataset.prototype.save = thenify(function (path, options = {}, done) {
       case 'wasb:': {
         const retry = new wc.lib.azure.ExponentialRetryPolicyFilter();
         const az = wc.lib.azure.createBlobService().withFilter(retry);
-        wc.outputSystemStream = az.createWriteStreamToBlockBlob(url.auth, `${url.path.slice(1)}/${p}${suffix}`);
+        wc.outputSystemStream = az.createWriteStreamToBlockBlob(url.auth, url.path.slice(1) + '/' + p + suffix);
 
         if (opt.gzip) {
           wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
           wc.outputStream.pipe(wc.outputSystemStream);
         } else
           wc.outputStream = wc.outputSystemStream;
-        wc.log('save stream:', url.auth, `${url.path.slice(1)}/${p}${suffix}`);
+        wc.log('save stream:', url.auth, url.path.slice(1) + '/' + p + suffix);
 
         break;
       }
       case 'file:':
       case null: {
-        wc.log('save_preiterate, stream saving to', `${url.path}/${p}${suffix}`);
+        wc.log('save_preiterate, stream saving to', url.path + '/' + p + suffix);
         wc.lib.mkdirp.sync(opt.path);
-        wc.outputSystemStream = fs.createWriteStream(`${url.path}/${p}${suffix}`);
+        wc.outputSystemStream = fs.createWriteStream(url.path + '/' + p + suffix);
 
         if (opt.gzip) {
           wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
@@ -329,10 +325,7 @@ Dataset.prototype.save = thenify(function (path, options = {}, done) {
       }
     },
     _postIterate: function (acc, opt, wc, p, done) {
-      let suffix = '';
-      if (opt.gzip) suffix = '.gz';
-      if (opt.parquet) suffix = '.parquet';
-
+      const suffix = opt.gzip ? '.gz' : opt.parquet ? '.parquet' : '';
       const { zlib, fs } = wc.lib;
 
       if (opt.stream) {
@@ -364,10 +357,10 @@ Dataset.prototype.save = thenify(function (path, options = {}, done) {
         const retry = new wc.lib.azure.ExponentialRetryPolicyFilter();
         const az = wc.lib.azure.createBlobService().withFilter(retry);
 
-        wc.log('upload', wc.exportFile, 'to', url.auth, `${url.path.slice(1)}/${p}${suffix}`);
+        wc.log('upload', wc.exportFile, 'to', url.auth, url.path.slice(1) + '/' + p + suffix);
         az.createBlockBlobFromLocalFile(
           url.auth,
-          `${url.path.slice(1)}/${p}${suffix}`,
+          url.path.slice(1) + '/' + p + suffix,
           wc.exportFile,
           null,
           err => {
@@ -385,7 +378,7 @@ Dataset.prototype.save = thenify(function (path, options = {}, done) {
         s3.upload(
           {
             Bucket: url.host,
-            Key: `${url.path.slice(1)}/${p}${suffix}`,
+            Key: url.path.slice(1) + '/' + p + suffix,
             Body: readStream
           }, 
           err => {
@@ -398,7 +391,7 @@ Dataset.prototype.save = thenify(function (path, options = {}, done) {
       case 'file:':
       case null: {
         wc.lib.mkdirp.sync(opt.path);
-        const writeStream = fs.createWriteStream(`${url.path}/${p}${suffix}`);
+        const writeStream = fs.createWriteStream(url.path + '/' + p + suffix);
         readStream.pipe(writeStream);
         writeStream.once('close', done);
         break;
@@ -421,9 +414,9 @@ Dataset.prototype.save = thenify(function (path, options = {}, done) {
 
   const csvStreamReducer = (acc, val, opt, wc) => {
     const { cvs: { sep = ';' } } = opt;
-    let i;
+
     if (val instanceof Object) {
-      for (i in val)
+      for (let i in val)
         acc += (val[i] ? val[i].toString() : '') + sep;
       acc = acc.substr(0, acc.length - 1);
     } else acc += val;
@@ -529,11 +522,12 @@ Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt = {
           tmp[tmpIndex] = res.data;
           complete++;
           busy--;
-          self.sc.dlog(task._start, 'part', task.pid, `from worker-${res.workerId}`, `(${complete}/${tasks.length})`);
+          self.sc.dlog(task._start, 'part', task.pid, 'from worker-' + res.workerId, '(' + complete + '/' + tasks.length + ')');
           
           if (!stop && complete < tasks.length) return runNext();
           
-          tmp.forEach(t => (result = combiner(result, t, opt)));
+          for (let i = 0; i < tmp.length; i++)
+            result = combiner(result, tmp[i], opt);
 
           self.sc.dlog(self.resultStart, 'result stage', self.totalStages + '/' + self.totalStages, 'done');
           done(error, result);

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -169,7 +169,7 @@ Dataset.prototype.countByValue = thenify(function (done) {
 });
 
 Dataset.prototype.countByKey = thenify(function (done) {
-  return this.mapValues(a => 1) // eslint-disable-line no-unused-vars
+  return this.mapValues(function () {return 1;})
     .reduceByKey((a, b) => a + b, 0)
     .collect(done);
 });

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -2,25 +2,25 @@
 
 'use strict';
 
-var fs = require('fs');
-var stream = require('stream');
-var inherits = require('util').inherits;
-var zlib = require('zlib');
+const fs = require('fs');
+const stream = require('stream');
+const inherits = require('util').inherits;
+const zlib = require('zlib');
 
-var thenify = require('thenify').withCallback;
-var uuid = require('uuid');
-var merge2 = require('merge2');
-var glob = require('glob');
-var micromatch = require('micromatch');
-var seedrandom = require('seedrandom');
-var aws = require('aws-sdk');
-var azure = require('azure-storage');
+const thenify = require('thenify').withCallback;
+const uuid = require('uuid');
+const merge2 = require('merge2');
+const glob = require('glob');
+const micromatch = require('micromatch');
+const seedrandom = require('seedrandom');
+const aws = require('aws-sdk');
+const azure = require('azure-storage');
 
 // Disable File split for now
 //var splitLocalFile = require('./readsplit.js').splitLocalFile;
 //var splitHDFSFile = require('./readsplit.js').splitHDFSFile;
 
-var parquet = require ('./stub-parquet.js');
+const parquet = require ('./stub-parquet.js');
 
 function Dataset(sc, dependencies) {
   this.id = sc.datasetIdCounter++;
@@ -56,17 +56,17 @@ Dataset.prototype.reduceByKey = function (reducer, init, args) {
 };
 
 Dataset.prototype.groupByKey = function () {
-  function reducer(a, b) {a.push(b); return a;}
-  function combiner(a, b) {return a.concat(b);}
+  const reducer = (a, b) => {a.push(b); return a;};
+  const combiner = (a, b) => {return a.concat(b);};
   return new AggregateByKey(this.sc, [this], reducer, combiner, [], {});
 };
 
 Dataset.prototype.coGroup = function (other) {
-  function reducer(a, b) {a.push(b); return a;}
-  function combiner(a, b) {
+  const reducer = (a, b) => {a.push(b); return a;};
+  const combiner = (a, b) => {
     for (var i = 0; i < b.length; i++) a[i] = a[i].concat(b[i]);
     return a;
-  }
+  };
   return new AggregateByKey(this.sc, [this, other], reducer, combiner, [], {});
 };
 
@@ -85,8 +85,10 @@ Dataset.prototype.sortByKey = function (ascending, numPartitions) {
 };
 
 Dataset.prototype.join = function (other) {
-  return this.coGroup(other).flatMapValues(function (v) {
-    var res = [], i, j;
+  return this.coGroup(other).flatMapValues(v => {
+    const res = [];
+    let i, j;
+
     for (i in v[0])
       for (j in v[1])
         res.push([v[0][i], v[1][j]]);
@@ -95,8 +97,10 @@ Dataset.prototype.join = function (other) {
 };
 
 Dataset.prototype.leftOuterJoin = function (other) {
-  return this.coGroup(other).flatMapValues(function (v) {
-    var res = [], i, j;
+  return this.coGroup(other).flatMapValues(v => {
+    const res = [];
+    let i, j;
+
     if (v[1].length === 0) {
       for (i in v[0]) res.push([v[0][i], null]);
     } else {
@@ -108,8 +112,10 @@ Dataset.prototype.leftOuterJoin = function (other) {
 };
 
 Dataset.prototype.rightOuterJoin = function (other) {
-  return this.coGroup(other).flatMapValues(function (v) {
-    var res = [], i, j;
+  return this.coGroup(other).flatMapValues(v => {
+    const res = [];
+    let i, j;
+
     if (v[0].length === 0) {
       for (i in v[1]) res.push([null, v[1][i]]);
     } else {
@@ -121,75 +127,74 @@ Dataset.prototype.rightOuterJoin = function (other) {
 };
 
 Dataset.prototype.distinct = function () {
-  return this.map(function (e) {return [e, null];})
-    .reduceByKey(function (a) {return a;}, null)
-    .map(function (a) {return a[0];});
+  return this.map(e => [e, null])
+    .reduceByKey(a => a, null)
+    .map(a => a[0]);
 };
 
 Dataset.prototype.intersection = function (other) {
-  function mapper(e) {return [e, 0];}
-  function reducer(a) {return a + 1;}
-  var a = this.map(mapper).reduceByKey(reducer, 0);
-  var b = other.map(mapper).reduceByKey(reducer, 0);
-  return a.coGroup(b).flatMap(function (a) {
+  const mapper = e => [e, 0];
+  const reducer = a => a + 1;
+  const a = this.map(mapper).reduceByKey(reducer, 0);
+  const b = other.map(mapper).reduceByKey(reducer, 0);
+  return a.coGroup(b).flatMap(a => {
     return (a[1][0].length && a[1][1].length) ? [a[0]] : [];
   });
 };
 
 Dataset.prototype.subtract = function (other) {
-  function mapper(e) {return [e, 0];}
-  function reducer(a) {return a + 1;}
-  var a = this.map(mapper).reduceByKey(reducer, 0);
-  var b = other.map(mapper).reduceByKey(reducer, 0);
-  return a.coGroup(b).flatMap(function (a) {
-    var res = [];
+  const mapper = e => [e, 0];
+  const reducer = a => a + 1;
+  const a = this.map(mapper).reduceByKey(reducer, 0);
+  const b = other.map(mapper).reduceByKey(reducer, 0);
+  return a.coGroup(b).flatMap(a => {
+    const res = [];
     if (a[1][0].length && (a[1][1].length === 0))
       for (var i = 0; i < a[1][0][0]; i++) res.push(a[0]);
     return res;
   });
 };
 
-Dataset.prototype.keys = function () {return this.map(function (a) {return a[0];});};
+Dataset.prototype.keys = function () {return this.map(a => a[0]);};
 
-Dataset.prototype.values = function () {return this.map(function (a) {return a[1];});};
+Dataset.prototype.values = function () {return this.map(a => a[1]);};
 
 Dataset.prototype.lookup = thenify(function (key, done) {
-  return this.filter(function (kv, args) {return kv[0] === args.key;}, {key: key})
-    .map(function (kv) {return kv[1];}).collect(done);
+  return this.filter((kv, args) => kv[0] === args.key, {key})
+    .map(kv => kv[1])
+    .collect(done);
 });
 
 Dataset.prototype.countByValue = thenify(function (done) {
-  return this.map(function (e) {return [e, 1];})
-    .reduceByKey(function (a, b) {return a + b;}, 0)
+  return this.map(e => [e, 1])
+    .reduceByKey((a, b) => a + b, 0)
     .collect(done);
 });
 
 Dataset.prototype.countByKey = thenify(function (done) {
-  return this.mapValues(function () {return 1;})
-    .reduceByKey(function (a, b) {return a + b;}, 0)
+  return this.mapValues(a => 1) // eslint-disable-line no-unused-vars
+    .reduceByKey((a, b) => a + b, 0)
     .collect(done);
 });
 
 Dataset.prototype.collect = thenify(function (done) {
-  return this.aggregate(function (a, b) {a.push(b); return a;}, function (a, b) {return a.concat(b);}, [], done);
+  return this.aggregate((a, b) => {a.push(b); return a;}, (a, b) => a.concat(b), [], done);
 });
 
 // The stream action allows the master to return a dataset as a stream
 // Each worker spills its partitions to disk
 // then master pipes each remote partition into output stream
-Dataset.prototype.stream = function (options) {
-  options = options || {};
-  var self = this;
-  var outStream = merge2();
-  var opt = {
+Dataset.prototype.stream = function (options = {}) {
+  const self = this;
+  const outStream = merge2();
+  const opt = {
     gzip: options.gzip,
     _preIterate: function (opt, wc, p) {
-      var suffix = opt.gzip ? '.gz' : '';
+      const suffix = opt.gzip ? '.gz' : '';
       wc.exportFile = wc.basedir + 'export/' + p + suffix;
     },
     _postIterate: function (acc, opt, wc, p, done) {
-      var fs = wc.lib.fs;
-      var zlib = wc.lib.zlib;
+      const { fs, zlib } = wc.lib;
       if (opt.gzip) {
         fs.appendFileSync(wc.exportFile, zlib.gzipSync(acc, {
           chunckSize: 65536,
@@ -201,14 +206,13 @@ Dataset.prototype.stream = function (options) {
       done(wc.exportFile);
     }
   };
-  var pstreams = [];
+  const pstreams = [];
 
-  function reducer(acc, val, opt, wc) {
+  const reducer = (acc, val, opt, wc) => {
     acc += JSON.stringify(val) + '\n';
     if (acc.length >= 65536) {
-      var fs = wc.lib.fs;
+      const { fs, zlib } = wc.lib;
       if (opt.gzip) {
-        var zlib = wc.lib.zlib;
         fs.appendFileSync(wc.exportFile, zlib.gzipSync(acc, {
           chunckSize: 65536,
           level: zlib.Z_BEST_SPEED
@@ -219,16 +223,15 @@ Dataset.prototype.stream = function (options) {
       acc = '';
     }
     return acc;
-  }
+  };
 
-  function combiner(acc1, acc2) {
+  const combiner = (acc1, acc2) => {
     var p = acc2.path.match(/.+\/([0-9]+)/)[1];
     pstreams[p] = self.sc.getReadStreamSync(acc2);
-  }
+  };
 
-  this.aggregate(reducer, combiner, '', opt, function () {
-    for (var i = 0; i < pstreams.length; i++)
-      outStream.add(pstreams[i]);
+  this.aggregate(reducer, combiner, '', opt, () => {
+    pstreams.forEach(pstream => outStream.add(pstream));
   });
 
   if (options.end) outStream.once('end', self.sc.end);
@@ -244,29 +247,35 @@ Dataset.prototype.stream = function (options) {
 // This is necessary because all pipeline functions are synchronous
 // and to avoid back pressure during streaming out.
 //
-Dataset.prototype.save = thenify(function (path, options, done) {
-  options = options || {};
+Dataset.prototype.save = thenify(function (path, options = {}, done) {
   if (arguments.length < 3) done = options;
   path = path.replace(/\/+$/, '');  // Trim trailing slashes (confusing for S3)
-  var opt = {
+  const opt = {
     gzip: options.gzip,
     parquet: options.parquet,
     stream: options.stream,
     csv: options.csv,
     path: path,
     _preIterate: function (opt, wc, p) {
-      var suffix = opt.gzip ? '.gz' : opt.parquet ? '.parquet' : '';
-      if (opt.csv) suffix = '.csv' + suffix;
-      wc.exportFile = wc.basedir + 'export/' + p + suffix;
+      let suffix = '';
+
+      if (opt.gzip) suffix = '.gz';
+      if (opt.parquet) suffix = '.parquet';
+      if (opt.csv) suffix = `.csv${suffix}`;
+
+      wc.exportFile = `${wc.basedir}export/${p}${suffix}`;
+
       if (opt.parquet) {
         wc.parquetFile = new wc.lib.parquet.ParquetWriter(wc.exportFile, opt.parquet.schema, opt.parquet.compression);
       }
       if (!opt.stream) return;
-      var url = wc.lib.url.parse(opt.path);
-      var zlib = wc.lib.zlib, fs = wc.lib.fs;
+
+      const url = wc.lib.url.parse(opt.path);
+      const { zlib, fs } = wc.lib;
+
       switch (url.protocol) {
-      case 's3:':
-        var s3 = new wc.lib.aws.S3({httpOptions: {timeout: 3600000}, signatureVersion: 'v4'});
+      case 's3:': {
+        const s3 = new wc.lib.aws.S3({httpOptions: {timeout: 3600000}, signatureVersion: 'v4'});
         if (opt.gzip) {
           wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
         } else {
@@ -274,48 +283,58 @@ Dataset.prototype.save = thenify(function (path, options, done) {
         }
         wc.uploadPromise = s3.upload({
           Bucket: url.host,
-          Key: url.path.slice(1) + '/' + p + suffix,
+          Key: `${url.path.slice(1)}/${p}${suffix}`,
           Body: wc.outputStream
-        }, function (err) {
+        }, err => {
           if (err) wc.log('S3 upload error', err);
           done();
         }).promise();
         break;
-      case 'wasb:':
-        var retry = new wc.lib.azure.ExponentialRetryPolicyFilter();
-        var az = wc.lib.azure.createBlobService().withFilter(retry);
-        wc.outputSystemStream = az.createWriteStreamToBlockBlob(url.auth, url.path.slice(1) + '/' + p + suffix);
+      }
+      case 'wasb:': {
+        const retry = new wc.lib.azure.ExponentialRetryPolicyFilter();
+        const az = wc.lib.azure.createBlobService().withFilter(retry);
+        wc.outputSystemStream = az.createWriteStreamToBlockBlob(url.auth, `${url.path.slice(1)}/${p}${suffix}`);
+
         if (opt.gzip) {
           wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
           wc.outputStream.pipe(wc.outputSystemStream);
         } else
           wc.outputStream = wc.outputSystemStream;
-        wc.log('save stream:', url.auth, url.path.slice(1) + '/' + p + suffix);
+        wc.log('save stream:', url.auth, `${url.path.slice(1)}/${p}${suffix}`);
+
         break;
+      }
       case 'file:':
-      case null:
-        wc.log('save_preiterate, stream saving to', url.path + '/' + p + suffix);
+      case null: {
+        wc.log('save_preiterate, stream saving to', `${url.path}/${p}${suffix}`);
         wc.lib.mkdirp.sync(opt.path);
-        wc.outputSystemStream = fs.createWriteStream(url.path + '/' + p + suffix);
+        wc.outputSystemStream = fs.createWriteStream(`${url.path}/${p}${suffix}`);
+
         if (opt.gzip) {
           wc.outputStream = zlib.createGzip({chunkSize: 65536, level: zlib.Z_BEST_SPEED});
           wc.outputStream.pipe(wc.outputSystemStream);
         } else
           wc.outputStream = wc.outputSystemStream;
+
         break;
+      }
       default:
         wc.log('Error: unsupported protocol', url.protocol);
       }
+
       if (opt.csv && opt.csv.header) {
         if (wc.outputStream)
           wc.outputStream.write(opt.csv.header + '\n');
       }
     },
     _postIterate: function (acc, opt, wc, p, done) {
-      var suffix = opt.gzip ? '.gz' : opt.parquet ? '.parquet' : '';
-      var fs = wc.lib.fs;
-      var zlib = wc.lib.zlib;
-      var url, readStream, writeStream;
+      let suffix = '';
+      if (opt.gzip) suffix = '.gz';
+      if (opt.parquet) suffix = '.parquet';
+
+      const { zlib, fs } = wc.lib;
+
       if (opt.stream) {
         wc.outputStream.end(acc);
         if (wc.outputSystemStream) {
@@ -336,42 +355,54 @@ Dataset.prototype.save = thenify(function (path, options, done) {
       } else {
         fs.appendFileSync(wc.exportFile, acc);
       }
-      readStream = fs.createReadStream(wc.exportFile);
-      url = wc.lib.url.parse(opt.path);
+
+      const readStream = fs.createReadStream(wc.exportFile);
+      const url = wc.lib.url.parse(opt.path);
+
       switch (url.protocol) {
-      case 'wasb:':
-        var retry = new wc.lib.azure.ExponentialRetryPolicyFilter();
-        var az = wc.lib.azure.createBlobService().withFilter(retry);
-        wc.log('upload', wc.exportFile, 'to', url.auth, url.path.slice(1) + '/' + p + suffix);
+      case 'wasb:': {
+        const retry = new wc.lib.azure.ExponentialRetryPolicyFilter();
+        const az = wc.lib.azure.createBlobService().withFilter(retry);
+
+        wc.log('upload', wc.exportFile, 'to', url.auth, `${url.path.slice(1)}/${p}${suffix}`);
         az.createBlockBlobFromLocalFile(
-          url.auth, url.path.slice(1) + '/' + p + suffix,
-          wc.exportFile, null, function (err) {
+          url.auth,
+          `${url.path.slice(1)}/${p}${suffix}`,
+          wc.exportFile,
+          null,
+          err => {
             if (err) wc.log('Azure upload error', err);
             done();
           }
         );
         break;
-      case 's3:':
-        var s3 = new wc.lib.aws.S3({
+      }
+      case 's3:': {
+        const s3 = new wc.lib.aws.S3({
           httpOptions: {timeout: 3600000},
           signatureVersion: 'v4'
         });
-        s3.upload({
-          Bucket: url.host,
-          Key: url.path.slice(1) + '/' + p + suffix,
-          Body: readStream
-        }, function (err) {
-          if (err) wc.log('S3 upload error', err);
-          done();
-        });
+        s3.upload(
+          {
+            Bucket: url.host,
+            Key: `${url.path.slice(1)}/${p}${suffix}`,
+            Body: readStream
+          }, 
+          err => {
+            if (err) wc.log('S3 upload error', err);
+            done();
+          }
+        );
         break;
+      }
       case 'file:':
-      case null:
+      case null: {
         wc.lib.mkdirp.sync(opt.path);
-        writeStream = fs.createWriteStream(url.path + '/' + p + suffix);
+        const writeStream = fs.createWriteStream(`${url.path}/${p}${suffix}`);
         readStream.pipe(writeStream);
         writeStream.once('close', done);
         break;
+      }
       default:
         wc.log('Error: unsupported protocol', url.protocol);
         done();
@@ -379,17 +410,18 @@ Dataset.prototype.save = thenify(function (path, options, done) {
     }
   };
 
-  function jsonStreamReducer(acc, val, opt, wc) {
+  const jsonStreamReducer = (acc, val, opt, wc) => {
     acc += JSON.stringify(val) + '\n';
     if (acc.length >= 65536) {
       wc.outputStreamOk = wc.outputStream.write(acc);
       acc = '';
     }
     return acc;
-  }
+  };
 
-  function csvStreamReducer(acc, val, opt, wc) {
-    var sep = opt.cvs && opt.cvs.sep || ';', i;
+  const csvStreamReducer = (acc, val, opt, wc) => {
+    const { cvs: { sep = ';' } } = opt;
+    let i;
     if (val instanceof Object) {
       for (i in val)
         acc += (val[i] ? val[i].toString() : '') + sep;
@@ -401,14 +433,13 @@ Dataset.prototype.save = thenify(function (path, options, done) {
       acc = '';
     }
     return acc;
-  }
+  };
 
-  function jsonFileReducer(acc, val, opt, wc) {
+  const jsonFileReducer = (acc, val, opt, wc) => {
     acc += JSON.stringify(val) + '\n';
     if (acc.length >= 65536) {
-      var fs = wc.lib.fs;
+      const { zlib, fs } = wc.lib;
       if (opt.gzip) {
-        var zlib = wc.lib.zlib;
         fs.appendFileSync(wc.exportFile, zlib.gzipSync(acc, {
           chunckSize: 65536,
           level: zlib.Z_BEST_SPEED
@@ -419,9 +450,9 @@ Dataset.prototype.save = thenify(function (path, options, done) {
       acc = '';
     }
     return acc;
-  }
+  };
 
-  function parquetReducer(acc, val, opt, wc) {
+  const parquetReducer = (acc, val, opt, wc) => {
     if (Array.isArray(val)) acc.push(val);
     else acc.push([val]);
     if (acc.length >= 10000) {
@@ -429,32 +460,32 @@ Dataset.prototype.save = thenify(function (path, options, done) {
       acc = [];
     }
     return acc;
-  }
+  };
 
   if (opt.parquet)
-    return this.aggregate(parquetReducer, function(){}, [], opt, done);
+    return this.aggregate(parquetReducer, () => {}, [], opt, done);
   if (opt.stream) {
     if (opt.csv)
-      return this.aggregate(csvStreamReducer, function() {}, '', opt, done);
-    return this.aggregate(jsonStreamReducer, function(){}, '', opt, done);
+      return this.aggregate(csvStreamReducer, () => {}, '', opt, done);
+    return this.aggregate(jsonStreamReducer, () => {}, '', opt, done);
   }
-  return this.aggregate(jsonFileReducer, function(){}, '', opt, done);
+  return this.aggregate(jsonFileReducer, () => {}, '', opt, done);
 });
 
 Dataset.prototype.take = thenify(function (N, done) {
-  var reducer = function (a, b, opt) {if (a.length < opt._max) a.push(b); return a;};
-  var combiner = function (a, b, opt) {return ((a.length < opt._max) ? a.concat(b) : a).slice(0, opt._max);};
+  const reducer = (a, b, opt) => {if (a.length < opt._max) a.push(b); return a;};
+  const combiner = (a, b, opt) => {return ((a.length < opt._max) ? a.concat(b) : a).slice(0, opt._max);};
   return this.aggregate(reducer, combiner, [], {_max: N, _maxBusy: 1}, done);
 });
 
 Dataset.prototype.top = thenify(function (N, done) {
-  var reducer = function (a, b, opt) {a.push(b); return (a.length > opt._max) ? a.slice(1) : a;};
-  var combiner = function (a, b, opt) {return ((a.length < opt._max) ? b.concat(a) : a).slice(-opt._max);};
+  const reducer = (a, b, opt) => {a.push(b); return (a.length > opt._max) ? a.slice(1) : a;};
+  const combiner = (a, b, opt) => {return ((a.length < opt._max) ? b.concat(a) : a).slice(-opt._max);};
   return this.aggregate(reducer, combiner, [], {_max: N, _maxBusy: 1, _lifo: true}, done);
 });
 
 Dataset.prototype.first = thenify(function (done) {
-  return this.take(1, function (err, res) {
+  return this.take(1, (err, res) => {
     if (res) done(err, res[0]);
     else done(err);
   });
@@ -467,40 +498,43 @@ Dataset.prototype.first = thenify(function (done) {
 // * _maxBusy: maximum number of parallel aggregate tasks. Set to 1 by take and top.
 // * _lifo: enable partition processing from last to first. Set by top.
 //
-Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, done) {
-  opt = opt || {};
+Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt = {}, done) {
   var action = {args: [], src: reducer, init: init, opt: opt};
   var self = this;
 
   if (arguments.length < 5) done = opt;
 
-  return this.sc.runJob(opt, this, action, function (job, tasks) {
-    var tmp = [];                                     // Pending tasks results waiting for combine
-    var result = deepCopy(init);                      // reducer/combiner result init
-    var index = opt._lifo ? tasks.length - 1 : 0;     // start from 0, or last if top action
-    var lastIndex = opt._lifo ? 0 : tasks.length;     // 0 for top action
-    var maxBusy = opt._maxBusy || self.sc.worker.length;  // set to 1 for take/top
-    var incr = opt._lifo ? -1 : 1;
-    var busy = 0;                                     // Number of busy tasks
-    var complete = 0;
-    var error;
+  return this.sc.runJob(opt, this, action, (job, tasks) => {
+    const tmp = [];                                         // Pending tasks results waiting for combine
+    const lastIndex = opt._lifo ? 0 : tasks.length;         // 0 for top action
+    const maxBusy = opt._maxBusy || self.sc.worker.length;  // set to 1 for take/top
+    const incr = opt._lifo ? -1 : 1;
+    let index = opt._lifo ? tasks.length - 1 : 0;           // start from 0, or last if top action
+    let result = deepCopy(init);                            // reducer/combiner result init
+    let busy = 0;                                           // Number of busy tasks
+    let complete = 0;
+    let error;
 
     function runNext() {
       while (busy < maxBusy && index !== lastIndex) {
-        self.sc.runTask(tasks[index], function (err, res, task) {
+        self.sc.runTask(tasks[index], (err, res, task) => {
           if (err) {
             // FIXME: should handle task re-submit here for fault tolerance
             console.error('ERROR: aggregate partition', task.pid);
           }
-          var i, stop = opt._max && res.data.length >= opt._max;
-          var tmpIndex = opt._lifo ? tasks.length - 1 - task.pid : task.pid;
+
+          const stop = opt._max && res.data.length >= opt._max;
+          const tmpIndex = opt._lifo ? tasks.length - 1 - task.pid : task.pid;
+          
           tmp[tmpIndex] = res.data;
           complete++;
           busy--;
-          self.sc.dlog(task._start, 'part', task.pid, 'from worker-' + res.workerId, '(' + complete + '/' + tasks.length + ')');
+          self.sc.dlog(task._start, 'part', task.pid, `from worker-${res.workerId}`, `(${complete}/${tasks.length})`);
+          
           if (!stop && complete < tasks.length) return runNext();
-          for (i = 0; i < tmp.length; i++)
-            result = combiner(result, tmp[i], opt);
+          
+          tmp.forEach(t => (result = combiner(result, t, opt)));
+
           self.sc.dlog(self.resultStart, 'result stage', self.totalStages + '/' + self.totalStages, 'done');
           done(error, result);
         });
@@ -513,28 +547,27 @@ Dataset.prototype.aggregate = thenify(function (reducer, combiner, init, opt, do
   });
 });
 
-Dataset.prototype.reduce = thenify(function (reducer, init, opt, done) {
-  opt = opt || {};
+Dataset.prototype.reduce = thenify(function (reducer, init, opt = {}, done) {
   if (arguments.length < 4) done = opt;
   return this.aggregate(reducer, reducer, init, opt, done);
 });
 
 Dataset.prototype.count = thenify(function (done) {
-  return this.aggregate(function (a) {return a + 1;}, function (a, b) {return a + b;}, 0, done);
+  return this.aggregate(a => a + 1, (a, b) => a + b, 0, done);
 });
 
 Dataset.prototype.forEach = thenify(function (eacher, opt, done) {
-  var arg = {opt: opt, _foreach: true};
+  var arg = {opt, _foreach: true};
   if (arguments.length < 3) done = opt;
-  return this.aggregate(eacher, function () {return null;}, null, arg, done);
+  return this.aggregate(eacher, () => null, null, arg, done);
 });
 
 Dataset.prototype.getPartitions = function (done) {
   if (this.partitions === undefined) {
     this.partitions = {};
-    var cnt = 0;
-    for (var i = 0; i < this.dependencies.length; i++) {
-      for (var j = 0; j < this.dependencies[i].nPartitions; j++) {
+    let cnt = 0;
+    for (let i = 0; i < this.dependencies.length; i++) {
+      for (let j = 0; j < this.dependencies[i].nPartitions; j++) {
         this.partitions[cnt] = new Partition(this.id, cnt, this.dependencies[i].id, this.dependencies[i].partitions[j].partitionIndex);
         cnt++;
       }
@@ -579,12 +612,12 @@ Dataset.prototype.takeSample = thenify(function (withReplacement, num, done) {
   if (!num) return done();
   this.count(function (err, total) {
     if (err || !total) return done(err);
-    if (total <= num) return this.collect(function (err, res) {done(err, randomizeArray(res));});
+    if (total <= num) return this.collect((err, res) => {done(err, randomizeArray(res));});
     const fraction = sampleSizeFraction(num, total, withReplacement);
     iterate();
 
     function iterate() {
-      self.sample(withReplacement, fraction).collect(function (err, result) {
+      self.sample(withReplacement, fraction).collect((err, result) => {
         if (result.length < num) return iterate();
         done(err, randomizeArray(result).slice(0, num));
       });


### PR DESCRIPTION
Hey, 

Here's the first pass at converting the `Dataset` Object and all it's Prototype methods over to using modern JS. 

I went with pretty standard stuff to start with however I think there's room for improving it further with Array prototypes that are now available eg. `map, reduce, forEach, etc.`. The issue I was having was context on most functions intend that I decided not to venture into refactors that way yet. 

Let me know your thoughts. This PR can either move ahead and get merge (after appropriate review of course) or I can continue on here with the rest of this file if everyone is okay with that. 

**Note** all prototype definitions stayed as `function () {}` declarations so that the `this` scope would be correct. 